### PR TITLE
Add missing params for `access_codes->get`

### DIFF
--- a/src/SeamClient.php
+++ b/src/SeamClient.php
@@ -265,11 +265,15 @@ final class AccessCodesClient
     );
   }
 
-  public function get(string $access_code_id, string $device_id = null): AccessCode
-  {
+  public function get(
+    string $access_code_id = null,
+    string $device_id = null,
+    string $code = null
+  ): AccessCode {
     $query = filter_out_null_params([
       "access_code_id" => $access_code_id,
-      "device_id" => $device_id
+      "device_id" => $device_id,
+      "code" => $code
     ]);
 
     return AccessCode::from_json(

--- a/src/SeamClient.php
+++ b/src/SeamClient.php
@@ -265,13 +265,18 @@ final class AccessCodesClient
     );
   }
 
-  public function get(string $access_code_id): AccessCode
+  public function get(string $access_code_id, string $device_id = null): AccessCode
   {
+    $query = filter_out_null_params([
+      "access_code_id" => $access_code_id,
+      "device_id" => $device_id
+    ]);
+
     return AccessCode::from_json(
       $this->seam->request(
         "GET",
         "access_codes/get",
-        query: ["access_code_id" => $access_code_id],
+        query: $query,
         inner_object: "access_code"
       )
     );

--- a/tests/AccessCodesTest.php
+++ b/tests/AccessCodesTest.php
@@ -21,5 +21,8 @@ final class AccessCodesTest extends TestCase
     $access_code_id = $access_codes[0]->access_code_id;
     $access_code = $seam->access_codes->get(access_code_id: $access_code_id);
     $this->assertTrue($access_code->access_code_id === $access_code_id);
+
+    // $access_code = $seam->access_codes->get(device_id: $device_id);
+    // $this->assertIsObject($access_code);
   }
 }

--- a/tests/AccessCodesTest.php
+++ b/tests/AccessCodesTest.php
@@ -19,10 +19,11 @@ final class AccessCodesTest extends TestCase
     $this->assertIsArray($access_codes);
 
     $access_code_id = $access_codes[0]->access_code_id;
+    print($access_code_id);
     $access_code = $seam->access_codes->get(access_code_id: $access_code_id);
     $this->assertTrue($access_code->access_code_id === $access_code_id);
 
-    // $access_code = $seam->access_codes->get(device_id: $device_id);
-    // $this->assertIsObject($access_code);
+    // $access_code = $seam->access_codes->get(device_id: $device_id, code: "1234");
+    // $this->assertTrue($access_code->code === "1234");
   }
 }

--- a/tests/AccessCodesTest.php
+++ b/tests/AccessCodesTest.php
@@ -23,7 +23,7 @@ final class AccessCodesTest extends TestCase
     $access_code = $seam->access_codes->get(access_code_id: $access_code_id);
     $this->assertTrue($access_code->access_code_id === $access_code_id);
 
-    // $access_code = $seam->access_codes->get(device_id: $device_id, code: "1234");
-    // $this->assertTrue($access_code->code === "1234");
+    $access_code = $seam->access_codes->get(device_id: $device_id, code: "1234");
+    $this->assertTrue($access_code->code === "1234");
   }
 }


### PR DESCRIPTION
fixes https://github.com/seamapi/php/issues/2