### PR TITLE
Implement `action_attempts->list`

### DIFF
--- a/src/SeamClient.php
+++ b/src/SeamClient.php
@@ -228,9 +228,6 @@ class ActionAttemptsClient
    */
   public function list(array $action_attempt_ids): array
   {
-    echo "ids";
-    print_r($action_attempt_ids);
-
     return array_map(
       fn ($a) => ActionAttempt::from_json($a),
       $this->seam->request(

--- a/src/SeamClient.php
+++ b/src/SeamClient.php
@@ -7,16 +7,10 @@ use Seam\Objects\ActionAttempt;
 use Seam\Objects\ConnectedAccount;
 use Seam\Objects\ConnectWebview;
 use Seam\Objects\Device;
-use Seam\Objects\DeviceProperties;
 use Seam\Objects\Event;
-use Seam\Objects\SeamError;
-use Seam\Objects\UserIdentifier;
 use Seam\Objects\Workspace;
 
 use GuzzleHttp\Client as HTTPClient;
-use GuzzleHttp\Exception\RequestException as RequestException;
-use GuzzleHttp\Exception\ClientException as ClientException;
-use GuzzleHttp\Exception\ClientErrorResponseException as ClientErrorResponseException;
 use \Exception as Exception;
 
 function filter_out_null_params(array $params)

--- a/src/SeamClient.php
+++ b/src/SeamClient.php
@@ -228,6 +228,26 @@ class ActionAttemptsClient
     );
   }
 
+  /**
+   * List action attempts
+   * @return ActionAttempt[]
+   */
+  public function list(array $action_attempt_ids): array
+  {
+    echo "ids";
+    print_r($action_attempt_ids);
+
+    return array_map(
+      fn ($a) => ActionAttempt::from_json($a),
+      $this->seam->request(
+        "GET",
+        "action_attempts/list",
+        query: ["action_attempt_ids" => implode(',', $action_attempt_ids)],
+        inner_object: "action_attempts"
+      )
+    );
+  }
+
   public function poll_until_ready(string $action_attempt_id): ActionAttempt
   {
     $seam = $this->seam;

--- a/tests/ActionAttemptsTest.php
+++ b/tests/ActionAttemptsTest.php
@@ -20,5 +20,8 @@ final class ActionAttemptsTest extends TestCase
 
     $updated_action_attempt = $seam->action_attempts->poll_until_ready($action_attempt_id);
     $this->assertEquals($updated_action_attempt->status, "success");
+
+    $action_attempts = $seam->action_attempts->list([$action_attempt_id]);
+    $this->assertTrue(count($action_attempts) > 0);
   }
 }


### PR DESCRIPTION
- support listing action attempts
- remove unnecessary imports
