### PR TITLE
Fix ends_at on AccessCode

### DIFF
--- a/src/Objects/AccessCode.php
+++ b/src/Objects/AccessCode.php
@@ -17,7 +17,7 @@ class AccessCode
             code: $json->code ?? null,
             status: $json->status ?? null,
             starts_at: $json->starts_at ?? null,
-            ends_at: $json->starts_at ?? null,
+            ends_at: $json->ends_at ?? null,
             errors: array_map(
                 fn($e) => SeamError::from_json($e),
                 $json->access_code_errors ?? []

--- a/tests/AccessCodesTest.php
+++ b/tests/AccessCodesTest.php
@@ -25,7 +25,6 @@ final class AccessCodesTest extends TestCase
     $this->assertIsArray($access_codes);
 
     $access_code_id = $access_codes[0]->access_code_id;
-    print($access_code_id);
     $access_code = $seam->access_codes->get(access_code_id: $access_code_id);
     $this->assertTrue($access_code->access_code_id === $access_code_id);
 
@@ -40,5 +39,23 @@ final class AccessCodesTest extends TestCase
     $access_code = $seam->access_codes->get(access_code_id: $access_code_id);
     $this->assertEquals($access_code->status, "removing");
     $this->assertEquals($action_attempt->status, "success");
+
+    $start_date = new DateTime("+2 months");
+    $end_date = new DateTime("+3 months");
+
+    $seam->access_codes->create(
+      device_id: $device_id,
+      code: "5678",
+      starts_at: $start_date->format(DateTime::ATOM),
+      ends_at: $end_date->format(DateTime::ATOM)
+    );
+
+    $access_code = $seam->access_codes->list(device_id: $device_id)[0];
+
+    $formatted_starts_at = (new DateTime($access_code->starts_at))->format("Y-m-d");
+    $formatted_ends_at = (new DateTime($access_code->ends_at))->format("Y-m-d");
+
+    $this->assertTrue($formatted_starts_at === $start_date->format("Y-m-d"));
+    $this->assertTrue($formatted_ends_at === $end_date->format("Y-m-d"));
   }
 }


### PR DESCRIPTION
Fix `ends_at` on Access Codes.

Add test to ensure is parsed properly.

