### PR TITLE
Allow for null codes on Access Codes from providers like Salto

### DIFF
--- a/src/Objects/AccessCode.php
+++ b/src/Objects/AccessCode.php
@@ -52,7 +52,7 @@ class AccessCode
          * The 4-8 digit code assigned to the device, note that this isn't always
          * immediately available after creating the access code.
          */
-        public string $code,
+        public string|null $code,
         public string $created_at,
 
         /* @var SeamError[] */


### PR DESCRIPTION
A few providers like Salto won't always return an access code immediately. This can cause an exception when the API response is serialized into an AccessCode object which requires the code to be of type string. 