### PR TITLE
fix 8.2 deprecations

### DIFF
--- a/src/Objects/DeviceProperties.php
+++ b/src/Objects/DeviceProperties.php
@@ -2,9 +2,11 @@
 
 namespace Seam\Objects;
 
+use stdClass;
+
 use function Seam\filter_out_null_params;
 
-class DeviceProperties
+class DeviceProperties extends stdClass
 {
   public static function from_json(mixed $json): DeviceProperties|null
   {
@@ -73,5 +75,10 @@ class DeviceProperties
     foreach ($params as $key => $value) {
       $this->$key = $value;
     }
+  }
+
+  public function __get($name): mixed
+  {
+      return $this->$name ?? null;
   }
 }

--- a/src/SeamClient.php
+++ b/src/SeamClient.php
@@ -35,6 +35,7 @@ class SeamClient
   public LocksClient $locks;
   public ClientSessionsClient $client_sessions;
   public NoiseSensorsClient $noise_sensors;
+  public ThermostatsClient $thermostats;
 
   public string $api_key;
   public HTTPClient $client;
@@ -1243,6 +1244,10 @@ class NoiseThresholdsClient
 class ThermostatsClient
 {
   private SeamClient $seam;
+
+  
+  public ClimateSettingSchedulesClient $climate_setting_schedules;
+
   public function __construct(SeamClient $seam)
   {
     $this->seam = $seam;


### PR DESCRIPTION
Dynamic properties in php 8.2 are deprecated, while they will still work it does add a lot of logging noise.
This should fix that.