### PR TITLE
Remove undocumented filtering from codegen, filter at blueprint creation

### DIFF
--- a/codegen/lib/resource-model.ts
+++ b/codegen/lib/resource-model.ts
@@ -33,36 +33,26 @@ export const createResourceObjectModel = (
   const baseResources = new Map<string, Property[]>()
 
   for (const resource of blueprint.resources) {
-    if (resource.isUndocumented) continue
-    baseResources.set(
-      resource.resourceType,
-      documentedProperties(resource.properties),
-    )
+    baseResources.set(resource.resourceType, resource.properties)
   }
 
   // The blueprint models events and action attempts as one resource per
   // variant. The PHP SDK has a single class for each, so the variants are
   // merged into one schema.
-  const events = blueprint.events.filter((event) => !event.isUndocumented)
+  const { events } = blueprint
   if (events.length > 0) {
     baseResources.set(
       'event',
-      mergeProperties(
-        events.map((event) => documentedProperties(event.properties)),
-      ),
+      mergeProperties(events.map((event) => event.properties)),
     )
   }
 
-  const actionAttempts = blueprint.actionAttempts.filter(
-    (actionAttempt) => !actionAttempt.isUndocumented,
-  )
+  const { actionAttempts } = blueprint
   if (actionAttempts.length > 0) {
     baseResources.set(
       'action_attempt',
       mergeProperties(
-        actionAttempts.map((actionAttempt) =>
-          documentedProperties(actionAttempt.properties),
-        ),
+        actionAttempts.map((actionAttempt) => actionAttempt.properties),
       ),
     )
   }
@@ -107,7 +97,7 @@ const createResourceObjectProperty = (
   const referenceName = pascalCase(`${baseName}_${property.name}`)
 
   if (property.format === 'object') {
-    const properties = documentedProperties(property.properties)
+    const { properties } = property
 
     if (properties.length > 0) {
       addSchema(referenceName, properties, baseName)
@@ -118,12 +108,10 @@ const createResourceObjectProperty = (
   if (property.format === 'list') {
     const itemProperties =
       property.itemFormat === 'object'
-        ? documentedProperties(property.itemProperties)
+        ? property.itemProperties
         : property.itemFormat === 'discriminated_object'
           ? mergeProperties(
-              property.variants.map((variant) =>
-                documentedProperties(variant.properties),
-              ),
+              property.variants.map((variant) => variant.properties),
             )
           : []
 
@@ -139,9 +127,6 @@ const createResourceObjectProperty = (
     phpType: getPhpType(property),
   }
 }
-
-const documentedProperties = (properties: Property[]): Property[] =>
-  properties.filter((property) => !property.isUndocumented)
 
 const mergeProperties = (propertyLists: Property[][]): Property[] => {
   const merged = new Map<string, Property>()

--- a/codegen/lib/routes.ts
+++ b/codegen/lib/routes.ts
@@ -70,17 +70,12 @@ export const routes = (
   }
 
   for (const route of blueprint.routes) {
-    if (route.isUndocumented) continue
-
-    const endpoints = route.endpoints.filter(
-      (endpoint) => !endpoint.isUndocumented,
-    )
-    if (endpoints.length === 0) continue
+    if (route.endpoints.length === 0) continue
 
     const namespaceSegments = route.path.split('/').filter((s) => s.length > 0)
     const client = ensureClient(namespaceSegments)
 
-    for (const endpoint of endpoints) {
+    for (const endpoint of route.endpoints) {
       client.methods.push(createClientMethod(endpoint))
     }
   }
@@ -114,9 +109,7 @@ const createClientMethod = (endpoint: Endpoint): PhpClientMethod => {
   return {
     methodName: endpoint.name,
     path: endpoint.path,
-    parameters: endpoint.request.parameters
-      .filter((parameter) => !parameter.isUndocumented)
-      .map((parameter) => ({
+    parameters: endpoint.request.parameters.map((parameter) => ({
         name: parameter.name,
         type: getPhpType(parameter),
         required: parameter.isRequired,

--- a/codegen/smith.ts
+++ b/codegen/smith.ts
@@ -2,7 +2,8 @@ import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import layouts from '@metalsmith/layouts'
-import { blueprint, getHandlebarsPartials } from '@seamapi/smith'
+import { createBlueprint } from '@seamapi/blueprint'
+import { getHandlebarsPartials } from '@seamapi/smith'
 import * as types from '@seamapi/types/connect'
 import { deleteAsync } from 'del'
 import Metalsmith from 'metalsmith'
@@ -15,11 +16,15 @@ await Promise.all([deleteAsync(['./src/Objects', './src/SeamClient.php'])])
 
 const partials = await getHandlebarsPartials(`${rootDir}/layouts/partials`)
 
+// Generate the blueprint with undocumented endpoints, resources, parameters,
+// and properties already omitted, so the codegen only sees the public API.
+const blueprint = await createBlueprint({ ...types }, { omitUndocumented: true })
+
 Metalsmith(rootDir)
   .source('./content')
   .destination('../')
   .clean(false)
-  .use(blueprint({ types }))
+  .metadata({ blueprint })
   .use(routes)
   .use(
     layouts({


### PR DESCRIPTION
## Summary
This PR refactors the undocumented content filtering logic by moving it upstream to the blueprint creation step, rather than filtering throughout the codegen code. This simplifies the codegen by removing scattered `isUndocumented` checks and `documentedProperties` filtering calls.

## Key Changes
- **Removed `documentedProperties` helper function** that filtered out undocumented properties - this filtering now happens at blueprint creation time
- **Simplified resource model generation** by removing `isUndocumented` checks for resources, events, and action attempts
- **Simplified route generation** by removing `isUndocumented` checks for routes and endpoints, and removing parameter filtering
- **Updated blueprint initialization** in `smith.ts` to use `createBlueprint` with `omitUndocumented: true` option, ensuring the blueprint only contains public API elements before codegen processes it

## Implementation Details
- The `createBlueprint` function from `@seamapi/blueprint` is now called with `omitUndocumented: true`, which pre-filters all undocumented resources, endpoints, parameters, and properties
- This eliminates the need for defensive filtering throughout the codegen pipeline
- The codegen now operates on a "clean" blueprint that only contains documented elements, making the code simpler and more maintainable
- Changed from using the `blueprint` plugin to directly passing the blueprint via metadata

https://claude.ai/code/session_01BrQiAv7j9XMWD12S9ax9Bt