### PR TITLE
refactor(codegen): use smith omitUndocumented option

### DIFF
--- a/codegen/smith.ts
+++ b/codegen/smith.ts
@@ -2,8 +2,7 @@ import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import layouts from '@metalsmith/layouts'
-import { createBlueprint } from '@seamapi/blueprint'
-import { getHandlebarsPartials } from '@seamapi/smith'
+import { blueprint, getHandlebarsPartials } from '@seamapi/smith'
 import * as types from '@seamapi/types/connect'
 import { deleteAsync } from 'del'
 import Metalsmith from 'metalsmith'
@@ -16,15 +15,13 @@ await Promise.all([deleteAsync(['./src/Objects', './src/SeamClient.php'])])
 
 const partials = await getHandlebarsPartials(`${rootDir}/layouts/partials`)
 
-// Generate the blueprint with undocumented endpoints, resources, parameters,
-// and properties already omitted, so the codegen only sees the public API.
-const blueprint = await createBlueprint({ ...types }, { omitUndocumented: true })
-
 Metalsmith(rootDir)
   .source('./content')
   .destination('../')
   .clean(false)
-  .metadata({ blueprint })
+  // Omit undocumented endpoints, resources, parameters, and properties so the
+  // codegen only sees the public API.
+  .use(blueprint({ types, omitUndocumented: true }))
   .use(routes)
   .use(
     layouts({

--- a/codegen/smith.ts
+++ b/codegen/smith.ts
@@ -19,8 +19,6 @@ Metalsmith(rootDir)
   .source('./content')
   .destination('../')
   .clean(false)
-  // Omit undocumented endpoints, resources, parameters, and properties so the
-  // codegen only sees the public API.
   .use(blueprint({ types, omitUndocumented: true }))
   .use(routes)
   .use(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "devDependencies": {
         "@prettier/plugin-php": "^0.24.0",
-        "@seamapi/blueprint": "^0.61.0",
-        "@seamapi/smith": "^0.5.2",
+        "@seamapi/blueprint": "^1.0.0",
+        "@seamapi/smith": "^1.0.0",
         "@seamapi/types": "1.975.0",
         "change-case": "^5.4.4",
         "prettier": "^3.0.0"
@@ -832,9 +832,9 @@
       "license": "MIT"
     },
     "node_modules/@seamapi/blueprint": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-0.61.0.tgz",
-      "integrity": "sha512-fNjl/4N6Up3quVPYrU4j9Bb34A/ib4a0EDm9g34H9phpMxc4ta7T2l0hGiz6jRY+CizQZNom8n+kDfOR+uHaIA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-1.0.0.tgz",
+      "integrity": "sha512-tQLylewWRJL1PWNxt9fXH/NWKIY0oA4NaQnRtRul0Dewy5yFqQy1fdi5IRPa7G3v+D9rrEiCwVA/omWrfrPZ+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -847,13 +847,13 @@
       }
     },
     "node_modules/@seamapi/smith": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@seamapi/smith/-/smith-0.5.2.tgz",
-      "integrity": "sha512-PRDe6Aa9bELyFyVyWp4UuWhmUtw80Hxr5u9jYB6ewKAHq8xePnoBpS3eZSiW1R8SN6UybLTzCWNepOpFRFRQjQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/smith/-/smith-1.0.0.tgz",
+      "integrity": "sha512-ZmwOJgSbyfEKit02/YPbklwecjIX1KT96ivc7KjY4IyDDoH9hqFflOngdm4GJwIKNCjN5g0fPExL67cUHJ1FPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^22.15.21",
+        "@types/node": "^24.10.9",
         "change-case": "^5.4.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -862,8 +862,8 @@
         "neostandard": "^0.12.2"
       },
       "engines": {
-        "node": ">=20.9.0",
-        "npm": ">=10.1.0"
+        "node": ">=22.11.0",
+        "npm": ">=10.9.4"
       },
       "peerDependencies": {
         "@metalsmith/layouts": "^2.7.0",
@@ -975,13 +975,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6205,9 +6205,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "devDependencies": {
     "@prettier/plugin-php": "^0.24.0",
-    "@seamapi/blueprint": "^0.61.0",
-    "@seamapi/smith": "^0.5.2",
+    "@seamapi/blueprint": "^1.0.0",
+    "@seamapi/smith": "^1.0.0",
     "@seamapi/types": "1.975.0",
     "change-case": "^5.4.4",
     "prettier": "^3.0.0"


### PR DESCRIPTION
## Summary

Follow-up to #451. Now that [`@seamapi/smith`](https://github.com/seamapi/smith)'s `blueprint` plugin forwards the `omitUndocumented` option, this replaces the direct `createBlueprint` workaround introduced in #451 with the standard plugin.

- Bump `@seamapi/blueprint` and `@seamapi/smith` to `^1.0.0`.
- Drop the direct `createBlueprint(...)` call + `.metadata({ blueprint })` wiring in `codegen/smith.ts` and go back to `.use(blueprint({ types, omitUndocumented: true }))`.

## Verification

- `npm run generate` produces **byte-for-byte identical** output (no changes under `src/`).
- `npm run typecheck` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrQiAv7j9XMWD12S9ax9Bt)_