### PR TITLE
feat: Add PHPDoc to SDK

### DIFF
--- a/codegen/layouts/partials/route-method.hbs
+++ b/codegen/layouts/partials/route-method.hbs
@@ -1,3 +1,4 @@
+{{{methodPhpDoc this}}}
     public function {{methodName}}({{{signatureParams}}}): {{returnType}} {
 {{#if hasParams}}
         $request_payload = [];

--- a/codegen/layouts/resource.hbs
+++ b/codegen/layouts/resource.hbs
@@ -3,6 +3,9 @@
 namespace Seam\Resources;
 
 {{#each classes}}
+{{#if (hasPhpDoc this)}}
+{{{resourcePhpDoc this}}}
+{{/if}}
 class {{className}}
 {
     public static function from_json(mixed $json): {{className}}|null
@@ -19,7 +22,10 @@ class {{className}}
 
     public function __construct(
 {{#each constructorParams}}
-        {{{this}}}
+{{#if (hasPhpDoc this)}}
+{{{propertyPhpDoc this}}}
+{{/if}}
+        {{{declaration}}}
 {{/each}}
     ) {
     }

--- a/codegen/lib/class-model.ts
+++ b/codegen/lib/class-model.ts
@@ -4,6 +4,7 @@
 export interface PhpClientMethodParameter {
   name: string
   type: string
+  description: string
   required?: boolean | undefined
   position?: number | undefined
 }
@@ -11,6 +12,10 @@ export interface PhpClientMethodParameter {
 export interface PhpClientMethod {
   methodName: string
   path: string
+  description: string
+  responseDescription: string
+  isDeprecated: boolean
+  deprecationMessage: string
   parameters: PhpClientMethodParameter[]
   returnResource: string
   returnPath: string

--- a/codegen/lib/handlebars-helpers.ts
+++ b/codegen/lib/handlebars-helpers.ts
@@ -1,1 +1,72 @@
 export const identity = (x: unknown): unknown => x
+
+export interface DeprecatedPhpDocContext {
+  description: string
+  isDeprecated: boolean
+  deprecationMessage: string
+}
+
+export interface MethodPhpDocContext extends DeprecatedPhpDocContext {
+  returnType: string
+  responseDescription: string
+  parameters: Array<{ name: string; type: string; description: string }>
+}
+
+export const resourcePhpDoc = (context: DeprecatedPhpDocContext): string =>
+  createPhpDoc(context.description, deprecatedTag(context))
+
+export const hasPhpDoc = (context: DeprecatedPhpDocContext): boolean =>
+  context.description.trim() !== '' || context.isDeprecated
+
+export const propertyPhpDoc = (context: DeprecatedPhpDocContext): string =>
+  createPhpDoc(context.description, deprecatedTag(context), '        ')
+
+export const methodPhpDoc = (context: MethodPhpDocContext): string =>
+  createPhpDoc(
+    context.description,
+    [
+      ...context.parameters.map(
+        (parameter) =>
+          `@param ${parameter.type} $${parameter.name}${parameter.description === '' ? '' : ` ${parameter.description}`}`,
+      ),
+      `@return ${context.returnType}${context.responseDescription === '' ? '' : ` ${context.responseDescription}`}`,
+      ...deprecatedTag(context),
+    ],
+    '    ',
+  )
+
+const deprecatedTag = (context: DeprecatedPhpDocContext): string[] =>
+  context.isDeprecated
+    ? [
+        `@deprecated${context.deprecationMessage === '' ? '' : ` ${context.deprecationMessage}`}`,
+      ]
+    : []
+
+const createPhpDoc = (
+  description: string,
+  tags: string[],
+  indentation = '',
+): string => {
+  const descriptionLines = description
+    .trim()
+    .split(/\r?\n/)
+    .map(sanitizePhpDocLine)
+  const populatedDescription = description.trim() === '' ? [] : descriptionLines
+  const populatedTags = tags.filter((tag) => tag.trim() !== '').map(sanitizePhpDocLine)
+  const lines = [
+    ...populatedDescription,
+    ...(populatedDescription.length > 0 && populatedTags.length > 0 ? [''] : []),
+    ...populatedTags,
+  ]
+
+  if (lines.length === 0) return ''
+
+  return [
+    `${indentation}/**`,
+    ...lines.map((line) => `${indentation} *${line === '' ? '' : ` ${line}`}`),
+    `${indentation} */`,
+  ].join('\n')
+}
+
+const sanitizePhpDocLine = (line: string): string =>
+  line.replaceAll('*/', '* /').trimEnd()

--- a/codegen/lib/layouts/resource.ts
+++ b/codegen/lib/layouts/resource.ts
@@ -15,8 +15,18 @@ import type {
 
 export interface ClassLayoutContext {
   className: string
+  description: string
+  isDeprecated: boolean
+  deprecationMessage: string
   fromJsonProps: string[]
-  constructorParams: string[]
+  constructorParams: ConstructorParamLayoutContext[]
+}
+
+export interface ConstructorParamLayoutContext {
+  declaration: string
+  description: string
+  isDeprecated: boolean
+  deprecationMessage: string
 }
 
 export interface ResourceLayoutContext {
@@ -38,19 +48,32 @@ const generateFromJsonProp = (property: ResourceClassProperty): string => {
   }
 }
 
-const generateConstructorParam = (property: ResourceClassProperty): string => {
+const generateConstructorParam = (
+  property: ResourceClassProperty,
+): ConstructorParamLayoutContext => {
+  let declaration: string
   switch (property.kind) {
     case 'objectReference':
-      return `public ${property.referenceName}|null $${property.name},`
+      declaration = `public ${property.referenceName}|null $${property.name},`
+      break
 
     case 'listReference':
-      return `public array $${property.name},`
+      declaration = `public array $${property.name},`
+      break
 
     case 'value': {
       const { phpType } = property
       const nullSuffix = phpType === 'mixed' ? '' : '|null'
-      return `public ${phpType}${nullSuffix} $${property.name},`
+      declaration = `public ${phpType}${nullSuffix} $${property.name},`
+      break
     }
+  }
+
+  return {
+    declaration,
+    description: property.description,
+    isDeprecated: property.isDeprecated,
+    deprecationMessage: property.deprecationMessage,
   }
 }
 
@@ -63,6 +86,9 @@ const getClassLayoutContext = (
 
   return {
     className: schema.name,
+    description: schema.description,
+    isDeprecated: schema.isDeprecated,
+    deprecationMessage: schema.deprecationMessage,
     fromJsonProps: sorted.map(generateFromJsonProp),
     constructorParams: sorted.map(generateConstructorParam),
   }

--- a/codegen/lib/layouts/seam-client.ts
+++ b/codegen/lib/layouts/seam-client.ts
@@ -10,6 +10,11 @@ import {
 
 export interface MethodLayoutContext {
   methodName: string
+  description: string
+  responseDescription: string
+  isDeprecated: boolean
+  deprecationMessage: string
+  parameters: Array<{ name: string; type: string; description: string }>
   path: string
   returnType: string
   hasParams: boolean
@@ -67,6 +72,15 @@ const getMethodLayoutContext = (
 
   return {
     methodName,
+    description: method.description,
+    responseDescription: method.responseDescription,
+    isDeprecated: method.isDeprecated,
+    deprecationMessage: method.deprecationMessage,
+    parameters: sortedParameters.map(({ name, type, description }) => ({
+      name,
+      type,
+      description,
+    })),
     path,
     returnType,
     hasParams: parameters.length > 0,

--- a/codegen/lib/resource-model.ts
+++ b/codegen/lib/resource-model.ts
@@ -15,12 +15,22 @@ import { pascalCase } from 'change-case'
 import { getPhpType } from './map-php-type.js'
 
 export type ResourceClassProperty =
-  | { name: string; kind: 'value'; phpType: string }
-  | { name: string; kind: 'objectReference'; referenceName: string }
-  | { name: string; kind: 'listReference'; referenceName: string }
+  | ({ kind: 'value'; phpType: string } & ResourceClassPropertyMetadata)
+  | ({ kind: 'objectReference'; referenceName: string } & ResourceClassPropertyMetadata)
+  | ({ kind: 'listReference'; referenceName: string } & ResourceClassPropertyMetadata)
+
+interface ResourceClassPropertyMetadata {
+  name: string
+  description: string
+  isDeprecated: boolean
+  deprecationMessage: string
+}
 
 export interface ResourceClassSchema {
   name: string
+  description: string
+  isDeprecated: boolean
+  deprecationMessage: string
   properties: ResourceClassProperty[]
 }
 
@@ -72,9 +82,18 @@ export const createResourceModel = (blueprint: Blueprint): ResourceModel => {
     name: string,
     properties: Property[],
     baseName: string,
+    description = '',
+    isDeprecated = false,
+    deprecationMessage = '',
   ): void => {
     if (classes.has(name)) return
-    const schema: ResourceClassSchema = { name, properties: [] }
+    const schema: ResourceClassSchema = {
+      name,
+      description,
+      isDeprecated,
+      deprecationMessage,
+      properties: [],
+    }
     classes.set(name, schema)
     if (name !== currentResourceName) {
       localClassNames.get(currentResourceName)?.push(name)
@@ -89,7 +108,17 @@ export const createResourceModel = (blueprint: Blueprint): ResourceModel => {
     const name = pascalCase(resourceType)
     currentResourceName = name
     localClassNames.set(name, [])
-    addClass(name, baseResources.get(resourceType) ?? [], resourceType)
+    const sourceResource =
+      blueprint.resources.find((resource) => resource.resourceType === resourceType) ??
+      (resourceType === 'event' ? blueprint.events[0] : blueprint.actionAttempts[0])
+    addClass(
+      name,
+      baseResources.get(resourceType) ?? [],
+      resourceType,
+      sourceResource?.description,
+      sourceResource?.isDeprecated,
+      sourceResource?.deprecationMessage,
+    )
 
     const resourceClass = classes.get(name)
     if (resourceClass == null) {
@@ -122,16 +151,29 @@ export const createResourceModel = (blueprint: Blueprint): ResourceModel => {
 const createResourceClassProperty = (
   property: Property,
   baseName: string,
-  addClass: (name: string, properties: Property[], baseName: string) => void,
+  addClass: (
+    name: string,
+    properties: Property[],
+    baseName: string,
+    description?: string,
+    isDeprecated?: boolean,
+    deprecationMessage?: string,
+  ) => void,
 ): ResourceClassProperty => {
   const referenceName = pascalCase(`${baseName}_${property.name}`)
+  const metadata = {
+    name: property.name,
+    description: property.description,
+    isDeprecated: property.isDeprecated,
+    deprecationMessage: property.deprecationMessage,
+  }
 
   if (property.format === 'object') {
     const { properties } = property
 
     if (properties.length > 0) {
-      addClass(referenceName, properties, baseName)
-      return { name: property.name, kind: 'objectReference', referenceName }
+      addClass(referenceName, properties, baseName, property.description)
+      return { ...metadata, kind: 'objectReference', referenceName }
     }
   }
 
@@ -146,13 +188,13 @@ const createResourceClassProperty = (
           : []
 
     if (itemProperties.length > 0) {
-      addClass(referenceName, itemProperties, baseName)
-      return { name: property.name, kind: 'listReference', referenceName }
+      addClass(referenceName, itemProperties, baseName, property.description)
+      return { ...metadata, kind: 'listReference', referenceName }
     }
   }
 
   return {
-    name: property.name,
+    ...metadata,
     kind: 'value',
     phpType: getPhpType(property),
   }

--- a/codegen/lib/routes.ts
+++ b/codegen/lib/routes.ts
@@ -110,9 +110,14 @@ const createClientMethod = (endpoint: Endpoint): PhpClientMethod => {
   return {
     methodName: endpoint.name,
     path: endpoint.path,
+    description: endpoint.description,
+    responseDescription: response.description,
+    isDeprecated: endpoint.isDeprecated,
+    deprecationMessage: endpoint.deprecationMessage,
     parameters: endpoint.request.parameters.map((parameter) => ({
         name: parameter.name,
         type: getPhpType(parameter),
+        description: parameter.description,
         required: parameter.isRequired,
         // The primary identifier of a get endpoint always sorts first in the
         // method signature.

--- a/src/Resources/AccessCode.php
+++ b/src/Resources/AccessCode.php
@@ -2,6 +2,17 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a smart lock [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+ *
+ * An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly. Using the Seam Access Code API, you can easily generate access codes on the hundreds of door lock models with which we integrate.
+ *
+ * Seam supports programming two types of access codes: [ongoing](https://docs.seam.co/low-level-apis/smart-locks/access-codes#ongoing-access-codes) and [time-bound](https://docs.seam.co/low-level-apis/smart-locks/access-codes#time-bound-access-codes). To differentiate between the two, refer to the `type` property of the access code. Ongoing codes display as `ongoing`, whereas time-bound codes are labeled `time_bound`. An ongoing access code is active, until it has been removed from the device. To specify an ongoing access code, leave both `starts_at` and `ends_at` empty. A time-bound access code will be programmed at the `starts_at` time and removed at the `ends_at` time.
+ *
+ * In addition, for certain devices, Seam also supports [offline access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes#offline-access-codes). Offline access (PIN) codes are designed for door locks that might not always maintain an internet connection. For this type of access code, the device manufacturer uses encryption keys (tokens) to create server-based registries of algorithmically-generated offline PIN codes. Because the tokens remain synchronized with the managed devices, the locks do not require an active internet connection—and you do not need to be near the locks—to create an offline access code. Then, owners or managers can share these offline codes with users through a variety of mechanisms, such as messaging applications. That is, lock users do not need to install a smartphone application to receive an offline access code.
+ *
+ * For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
+ */
 class AccessCode
 {
     public static function from_json(mixed $json): AccessCode|null
@@ -55,33 +66,108 @@ class AccessCode
     }
 
     public function __construct(
+        /**
+         * Unique identifier for the access code.
+         */
         public string|null $access_code_id,
+        /**
+         * Code used for access. Typically, a numeric or alphanumeric string.
+         */
         public string|null $code,
+        /**
+         * Unique identifier for a group of access codes that share the same code.
+         */
         public string|null $common_code_key,
+        /**
+         * Date and time at which the access code was created.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier for the device associated with the access code.
+         */
         public string|null $device_id,
+        /**
+         * Metadata for a dormakaba Oracode managed access code. Only present for access codes from dormakaba Oracode devices.
+         */
         public AccessCodeDormakabaOracodeMetadata|null $dormakaba_oracode_metadata,
+        /**
+         * Date and time after which the time-bound access code becomes inactive.
+         */
         public string|null $ends_at,
+        /**
+         * Errors associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+         */
         public array $errors,
+        /**
+         * Indicates whether the access code is a backup code.
+         */
         public bool|null $is_backup,
+        /**
+         * Indicates whether a backup access code is available for use if the primary access code is lost or compromised.
+         */
         public bool|null $is_backup_access_code_available,
+        /**
+         * Indicates whether changes to the access code from external sources are permitted.
+         */
         public bool|null $is_external_modification_allowed,
+        /**
+         * Indicates whether Seam manages the access code.
+         */
         public bool|null $is_managed,
+        /**
+         * Indicates whether the access code is intended for use in offline scenarios. If `true`, this code can be created on a device without a network connection.
+         */
         public bool|null $is_offline_access_code,
+        /**
+         * Indicates whether the access code can only be used once. If `true`, the code becomes invalid after the first use.
+         */
         public bool|null $is_one_time_use,
+        /**
+         * Indicates whether the code is set on the device according to a preconfigured schedule.
+         */
         public bool|null $is_scheduled_on_device,
+        /**
+         * Indicates whether the access code is waiting for a code assignment.
+         */
         public bool|null $is_waiting_for_code_assignment,
+        /**
+         * Name of the access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes. Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider's app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`. To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider's app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints. To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+         */
         public string|null $name,
+        /**
+         * Collection of pending mutations for the access code. Indicates changes that Seam is in the process of pushing to the device.
+         */
         public array $pending_mutations,
+        /**
+         * Identifier of the pulled backup access code. Used to associate the pulled backup access code with the original access code.
+         */
         public string|null $pulled_backup_access_code_id,
+        /**
+         * Date and time at which the time-bound access code becomes active.
+         */
         public string|null $starts_at,
+        /**
+         * Current status of the access code within the operational lifecycle. Values are `setting`, a transitional phase that indicates that the code is being configured or activated; `set`, which indicates that the code is active and operational; `unset`, which indicates a deactivated or unused state, either before activation or after deliberate deactivation; `removing`, which indicates a transitional period in which the code is being deleted or made inactive; and `unknown`, which indicates an indeterminate state, due to reasons such as system errors or incomplete data, that highlights a potential need for system review or troubleshooting. See also [Lifecycle of Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/lifecycle-of-access-codes).
+         */
         public string|null $status,
+        /**
+         * Type of the access code. `ongoing` access codes are active continuously until deactivated manually. `time_bound` access codes have a specific duration.
+         */
         public string|null $type,
+        /**
+         * Warnings associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+         */
         public array $warnings,
+        /**
+         * Unique identifier for the Seam workspace associated with the access code.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Metadata for a dormakaba Oracode managed access code. Only present for access codes from dormakaba Oracode devices.
+ */
 class AccessCodeDormakabaOracodeMetadata
 {
     public static function from_json(
@@ -103,17 +189,44 @@ class AccessCodeDormakabaOracodeMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether the stay can be cancelled via the Dormakaba Oracode API.
+         */
         public bool|null $is_cancellable,
+        /**
+         * Indicates whether early check-in is available for this stay.
+         */
         public bool|null $is_early_checkin_able,
+        /**
+         * Indicates whether the stay can be extended via the Dormakaba Oracode API.
+         */
         public bool|null $is_extendable,
+        /**
+         * Indicates whether the access code can be overridden. When false, the maximum number of overrides has been reached.
+         */
         public bool|null $is_overridable,
+        /**
+         * Dormakaba Oracode site name associated with this access code.
+         */
         public string|null $site_name,
+        /**
+         * Dormakaba Oracode stay ID associated with this access code.
+         */
         public float|null $stay_id,
+        /**
+         * Dormakaba Oracode user level ID associated with this access code.
+         */
         public string|null $user_level_id,
+        /**
+         * Dormakaba Oracode user level name associated with this access code.
+         */
         public string|null $user_level_name,
     ) {}
 }
 
+/**
+ * Errors associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+ */
 class AccessCodeErrors
 {
     public static function from_json(mixed $json): AccessCodeErrors|null
@@ -141,20 +254,56 @@ class AccessCodeErrors
     }
 
     public function __construct(
+        /**
+         * Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
+         */
         public string|null $change_type,
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Indicates that this is an access code error.
+         */
         public bool|null $is_access_code_error,
+        /**
+         * Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+         */
         public bool|null $is_bridge_error,
+        /**
+         * Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+         */
         public bool|null $is_connected_account_error,
+        /**
+         * Indicates that the error is not a device error.
+         */
         public bool|null $is_device_error,
+        /**
+         * ID of the managed access code that conflicts with this managed access code, when Seam can identify it.
+         */
         public string|null $managed_access_code_id,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * List of fields that were changed externally, with their previous and new values.
+         */
         public array $modified_fields,
+        /**
+         * ID of the unmanaged access code that conflicts with this managed access code, when Seam can identify it.
+         */
         public string|null $unmanaged_access_code_id,
     ) {}
 }
 
+/**
+ * Previous code configuration.
+ */
 class AccessCodeFrom
 {
     public static function from_json(mixed $json): AccessCodeFrom|null
@@ -171,13 +320,28 @@ class AccessCodeFrom
     }
 
     public function __construct(
+        /**
+         * Previous PIN code.
+         */
         public string|null $code,
+        /**
+         * Previous end time for the access code.
+         */
         public string|null $ends_at,
+        /**
+         * Previous access code name.
+         */
         public string|null $name,
+        /**
+         * Previous start time for the access code.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * List of fields that were changed externally, with their previous and new values.
+ */
 class AccessCodeModifiedFields
 {
     public static function from_json(mixed $json): AccessCodeModifiedFields|null
@@ -193,12 +357,24 @@ class AccessCodeModifiedFields
     }
 
     public function __construct(
+        /**
+         * The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+         */
         public string|null $field,
+        /**
+         * The previous value of the field.
+         */
         public string|null $from,
+        /**
+         * The new value of the field.
+         */
         public string|null $to,
     ) {}
 }
 
+/**
+ * Collection of pending mutations for the access code. Indicates changes that Seam is in the process of pushing to the device.
+ */
 class AccessCodePendingMutations
 {
     public static function from_json(
@@ -220,15 +396,36 @@ class AccessCodePendingMutations
     }
 
     public function __construct(
+        /**
+         * Date and time at which the mutation was created.
+         */
         public string|null $created_at,
+        /**
+         * Previous code configuration.
+         */
         public AccessCodeFrom|null $from,
+        /**
+         * Detailed description of the mutation.
+         */
         public string|null $message,
+        /**
+         * Mutation code to indicate that Seam is in the process of setting an access code on the device.
+         */
         public string|null $mutation_code,
+        /**
+         * Date and time at which Seam will attempt to program this access code on the device.
+         */
         public string|null $scheduled_at,
+        /**
+         * New code configuration.
+         */
         public AccessCodeTo|null $to,
     ) {}
 }
 
+/**
+ * New code configuration.
+ */
 class AccessCodeTo
 {
     public static function from_json(mixed $json): AccessCodeTo|null
@@ -245,13 +442,28 @@ class AccessCodeTo
     }
 
     public function __construct(
+        /**
+         * New PIN code.
+         */
         public string|null $code,
+        /**
+         * New end time for the access code.
+         */
         public string|null $ends_at,
+        /**
+         * New access code name.
+         */
         public string|null $name,
+        /**
+         * New start time for the access code.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Warnings associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+ */
 class AccessCodeWarnings
 {
     public static function from_json(mixed $json): AccessCodeWarnings|null
@@ -272,10 +484,25 @@ class AccessCodeWarnings
     }
 
     public function __construct(
+        /**
+         * Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
+         */
         public string|null $change_type,
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * List of fields that were changed externally, with their previous and new values.
+         */
         public array $modified_fields,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/AccessGrant.php
+++ b/src/Resources/AccessGrant.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an Access Grant. Access Grants enable you to grant a user identity access to spaces, entrances, and devices through one or more access methods, such as mobile keys, plastic cards, and PIN codes. You can create an Access Grant for an existing user identity, or you can create a new user identity *while* creating the new Access Grant.
+ */
 class AccessGrant
 {
     public static function from_json(mixed $json): AccessGrant|null
@@ -46,29 +49,92 @@ class AccessGrant
     }
 
     public function __construct(
+        /**
+         * ID of the Access Grant.
+         */
         public string|null $access_grant_id,
+        /**
+         * Unique key for the access grant within the workspace.
+         */
         public string|null $access_grant_key,
+        /**
+         * IDs of the access methods created for the Access Grant.
+         */
         public array|null $access_method_ids,
+        /**
+         * Client Session Token. Only returned if the Access Grant has a mobile_key access method.
+         */
         public string|null $client_session_token,
+        /**
+         * Date and time at which the Access Grant was created.
+         */
         public string|null $created_at,
+        /**
+         * ID of the customization profile associated with the Access Grant.
+         */
         public string|null $customization_profile_id,
+        /**
+         * Display name of the Access Grant.
+         */
         public string|null $display_name,
+        /**
+         * Date and time at which the Access Grant ends.
+         */
         public string|null $ends_at,
+        /**
+         * Errors associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+         */
         public array $errors,
+        /**
+         * Instant Key URL. Only returned if the Access Grant has a single mobile_key access_method.
+         */
         public string|null $instant_key_url,
+        /**
+         * @deprecated Use `space_ids`.
+         */
         public array|null $location_ids,
+        /**
+         * Name of the Access Grant. If not provided, the display name will be computed.
+         */
         public string|null $name,
+        /**
+         * List of pending mutations for the access grant. This shows updates that are in progress.
+         */
         public array $pending_mutations,
+        /**
+         * Access methods that the user requested for the Access Grant.
+         */
         public array $requested_access_methods,
+        /**
+         * Reservation key for the access grant.
+         */
         public string|null $reservation_key,
+        /**
+         * IDs of the spaces to which the Access Grant gives access.
+         */
         public array|null $space_ids,
+        /**
+         * Date and time at which the Access Grant starts.
+         */
         public string|null $starts_at,
+        /**
+         * ID of user identity to which the Access Grant gives access.
+         */
         public string|null $user_identity_id,
+        /**
+         * Warnings associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+         */
         public array $warnings,
+        /**
+         * ID of the Seam workspace associated with the Access Grant.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Errors associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+ */
 class AccessGrantErrors
 {
     public static function from_json(mixed $json): AccessGrantErrors|null
@@ -85,13 +151,28 @@ class AccessGrantErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * IDs of the devices that did not receive an access code at grant creation. Use these to identify which specific devices failed when the message reports a partial failure.
+         */
         public array|null $missing_device_ids,
     ) {}
 }
 
+/**
+ * Devices whose access codes could not be revoked during reconciliation. Present when the provider does not support revoking an offline access code (e.g. Dormakaba oracode with exhausted override budget).
+ */
 class AccessGrantFailedDevices
 {
     public static function from_json(mixed $json): AccessGrantFailedDevices|null
@@ -107,12 +188,24 @@ class AccessGrantFailedDevices
     }
 
     public function __construct(
+        /**
+         * Device whose access code could not be revoked.
+         */
         public string|null $device_id,
+        /**
+         * Reason the access code could not be revoked (e.g. `offline_access_code_not_revocable`).
+         */
         public string|null $error_code,
+        /**
+         * Human-readable description of why revocation failed.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Previous location configuration.
+ */
 class AccessGrantFrom
 {
     public static function from_json(mixed $json): AccessGrantFrom|null
@@ -128,12 +221,24 @@ class AccessGrantFrom
     }
 
     public function __construct(
+        /**
+         * Previous device IDs where access codes existed.
+         */
         public array|null $device_ids,
+        /**
+         * Previous end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * Previous start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * List of pending mutations for the access grant. This shows updates that are in progress.
+ */
 class AccessGrantPendingMutations
 {
     public static function from_json(
@@ -155,15 +260,36 @@ class AccessGrantPendingMutations
     }
 
     public function __construct(
+        /**
+         * IDs of the access methods being updated.
+         */
         public array|null $access_method_ids,
+        /**
+         * Date and time at which the mutation was created.
+         */
         public string|null $created_at,
+        /**
+         * Previous location configuration.
+         */
         public AccessGrantFrom|null $from,
+        /**
+         * Detailed description of the mutation.
+         */
         public string|null $message,
+        /**
+         * Mutation code to indicate that Seam is in the process of updating the spaces (devices) associated with this access grant.
+         */
         public string|null $mutation_code,
+        /**
+         * New location configuration.
+         */
         public AccessGrantTo|null $to,
     ) {}
 }
 
+/**
+ * Access methods that the user requested for the Access Grant.
+ */
 class AccessGrantRequestedAccessMethods
 {
     public static function from_json(
@@ -183,15 +309,36 @@ class AccessGrantRequestedAccessMethods
     }
 
     public function __construct(
+        /**
+         * Specific PIN code to use for this access method. Only applicable when mode is 'code'.
+         */
         public string|null $code,
+        /**
+         * IDs of the access methods created for the requested access method.
+         */
         public array|null $created_access_method_ids,
+        /**
+         * Date and time at which the requested access method was added to the Access Grant.
+         */
         public string|null $created_at,
+        /**
+         * Display name of the access method.
+         */
         public string|null $display_name,
+        /**
+         * Maximum number of times the instant key can be used. Only applicable when mode is 'mobile_key'. Defaults to 1 if not specified.
+         */
         public int|null $instant_key_max_use_count,
+        /**
+         * Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+         */
         public string|null $mode,
     ) {}
 }
 
+/**
+ * New location configuration.
+ */
 class AccessGrantTo
 {
     public static function from_json(mixed $json): AccessGrantTo|null
@@ -208,13 +355,28 @@ class AccessGrantTo
     }
 
     public function __construct(
+        /**
+         * Common code key to ensure PIN code reuse across devices.
+         */
         public string|null $common_code_key,
+        /**
+         * New device IDs where access codes should be created.
+         */
         public array|null $device_ids,
+        /**
+         * New end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * New start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Warnings associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+ */
 class AccessGrantWarnings
 {
     public static function from_json(mixed $json): AccessGrantWarnings|null
@@ -239,14 +401,41 @@ class AccessGrantWarnings
     }
 
     public function __construct(
+        /**
+         * IDs of the access methods being updated.
+         */
         public array|null $access_method_ids,
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * ID of the device where the requested code was unavailable.
+         */
         public string|null $device_id,
+        /**
+         * Devices whose access codes could not be revoked during reconciliation. Present when the provider does not support revoking an offline access code (e.g. Dormakaba oracode with exhausted override budget).
+         */
         public array $failed_devices,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * The new PIN code that was assigned instead.
+         */
         public string|null $new_code,
+        /**
+         * The originally requested PIN code that was unavailable.
+         */
         public string|null $original_code,
+        /**
+         * Specific reason why the grant's times are not programmable on the device.
+         */
         public string|null $reason,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/AccessMethod.php
+++ b/src/Resources/AccessMethod.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an access method for an Access Grant. Access methods describe the modes of access, such as PIN codes, plastic cards, and mobile keys. For a mobile key, the access method also stores the URL for the associated Instant Key.
+ */
 class AccessMethod
 {
     public static function from_json(mixed $json): AccessMethod|null
@@ -41,27 +44,84 @@ class AccessMethod
     }
 
     public function __construct(
+        /**
+         * ID of the access method.
+         */
         public string|null $access_method_id,
+        /**
+         * Token of the client session associated with the access method.
+         */
         public string|null $client_session_token,
+        /**
+         * The actual PIN code for code access methods.
+         */
         public string|null $code,
+        /**
+         * Date and time at which the access method was created.
+         */
         public string|null $created_at,
+        /**
+         * ID of the customization profile associated with the access method.
+         */
         public string|null $customization_profile_id,
+        /**
+         * Display name of the access method.
+         */
         public string|null $display_name,
+        /**
+         * Errors associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+         */
         public array $errors,
+        /**
+         * URL of the Instant Key for mobile key access methods.
+         */
         public string|null $instant_key_url,
+        /**
+         * Indicates whether an existing card credential must be assigned to this access method before it can be issued. Only applies to card-mode access methods on systems that support credential assignment.
+         */
         public bool|null $is_assignment_required,
+        /**
+         * Indicates whether encoding with an card encoder is required to issue or reissue the plastic card associated with the access method.
+         */
         public bool|null $is_encoding_required,
+        /**
+         * Indicates whether the access method has been issued.
+         */
         public bool|null $is_issued,
+        /**
+         * Indicates whether the access method is ready for card assignment. This is true when the access method is in card mode, has not yet been issued, and the system supports credential assignment.
+         */
         public bool|null $is_ready_for_assignment,
+        /**
+         * Indicates whether the access method is ready to be encoded. This is true when the credential has been created and the card has not yet been issued.
+         */
         public bool|null $is_ready_for_encoding,
+        /**
+         * Date and time at which the access method was issued.
+         */
         public string|null $issued_at,
+        /**
+         * Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+         */
         public string|null $mode,
+        /**
+         * Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
+         */
         public array $pending_mutations,
+        /**
+         * Warnings associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+         */
         public array $warnings,
+        /**
+         * ID of the Seam workspace associated with the access method.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Errors associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+ */
 class AccessMethodErrors
 {
     public static function from_json(mixed $json): AccessMethodErrors|null
@@ -77,12 +137,24 @@ class AccessMethodErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Previous device configuration.
+ */
 class AccessMethodFrom
 {
     public static function from_json(mixed $json): AccessMethodFrom|null
@@ -98,12 +170,24 @@ class AccessMethodFrom
     }
 
     public function __construct(
+        /**
+         * Previous device IDs where access was provisioned.
+         */
         public array|null $device_ids,
+        /**
+         * Previous end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * Previous start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
+ */
 class AccessMethodPendingMutations
 {
     public static function from_json(
@@ -124,14 +208,32 @@ class AccessMethodPendingMutations
     }
 
     public function __construct(
+        /**
+         * Date and time at which the mutation was created.
+         */
         public string|null $created_at,
+        /**
+         * Previous device configuration.
+         */
         public AccessMethodFrom|null $from,
+        /**
+         * Detailed description of the mutation.
+         */
         public string|null $message,
+        /**
+         * Mutation code to indicate that Seam is in the process of provisioning access for this access method on new devices.
+         */
         public string|null $mutation_code,
+        /**
+         * New device configuration.
+         */
         public AccessMethodTo|null $to,
     ) {}
 }
 
+/**
+ * New device configuration.
+ */
 class AccessMethodTo
 {
     public static function from_json(mixed $json): AccessMethodTo|null
@@ -147,12 +249,24 @@ class AccessMethodTo
     }
 
     public function __construct(
+        /**
+         * New device IDs where access is being provisioned.
+         */
         public array|null $device_ids,
+        /**
+         * New end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * New start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Warnings associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+ */
 class AccessMethodWarnings
 {
     public static function from_json(mixed $json): AccessMethodWarnings|null
@@ -169,9 +283,21 @@ class AccessMethodWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * ID of the original access method from which this backup access method was split, if applicable.
+         */
         public string|null $original_access_method_id,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/AcsAccessGroup.php
+++ b/src/Resources/AcsAccessGroup.php
@@ -2,6 +2,13 @@
 
 namespace Seam\Resources;
 
+/**
+ * Group that defines the entrances to which a set of users has access and, in some cases, the access schedule for these entrances and users.
+ *
+ * Some access control systems use [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups), which are sets of users, combined with sets of permissions. These permissions include both the set of areas or assets that the users can access and the schedule during which the users can access these areas or assets. Instead of assigning access rights individually to each access control system user, which can be time-consuming and error-prone, administrators can assign users to an access group, thereby ensuring that the users inherit all the permissions associated with the access group. Using access groups streamlines the process of managing large numbers of access control system users, especially in bigger organizations or complexes.
+ *
+ * To learn whether your access control system supports access groups, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+ */
 class AcsAccessGroup
 {
     public static function from_json(mixed $json): AcsAccessGroup|null
@@ -45,25 +52,76 @@ class AcsAccessGroup
     }
 
     public function __construct(
+        /**
+         * @deprecated Use `external_type`.
+         */
         public string|null $access_group_type,
+        /**
+         * @deprecated Use `external_type_display_name`.
+         */
         public string|null $access_group_type_display_name,
+        /**
+         * `starts_at` and `ends_at` timestamps for the access group's access.
+         */
         public AcsAccessGroupAccessSchedule|null $access_schedule,
+        /**
+         * ID of the access group.
+         */
         public string|null $acs_access_group_id,
+        /**
+         * ID of the access control system that contains the access group.
+         */
         public string|null $acs_system_id,
+        /**
+         * ID of the connected account that contains the access group.
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the access group was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name for the access group.
+         */
         public string|null $display_name,
+        /**
+         * Errors associated with the `acs_access_group`.
+         */
         public array $errors,
+        /**
+         * Brand-specific terminology for the access group type.
+         */
         public string|null $external_type,
+        /**
+         * Display name that corresponds to the brand-specific terminology for the access group type.
+         */
         public string|null $external_type_display_name,
+        /**
+         * Indicates whether Seam manages the access group.
+         */
         public bool|null $is_managed,
+        /**
+         * Name of the access group.
+         */
         public string|null $name,
+        /**
+         * Collection of pending mutations for the access group. Represents operations that have been requested but not yet completed on the integrated access system.
+         */
         public array $pending_mutations,
+        /**
+         * Warnings associated with the `acs_access_group`.
+         */
         public array $warnings,
+        /**
+         * ID of the workspace that contains the access group.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * `starts_at` and `ends_at` timestamps for the access group's access.
+ */
 class AcsAccessGroupAccessSchedule
 {
     public static function from_json(
@@ -79,11 +137,20 @@ class AcsAccessGroupAccessSchedule
     }
 
     public function __construct(
+        /**
+         * Date and time at which the user's access ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $ends_at,
+        /**
+         * Date and time at which the user's access starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Errors associated with the `acs_access_group`.
+ */
 class AcsAccessGroupErrors
 {
     public static function from_json(mixed $json): AcsAccessGroupErrors|null
@@ -99,12 +166,24 @@ class AcsAccessGroupErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Old access group information.
+ */
 class AcsAccessGroupFrom
 {
     public static function from_json(mixed $json): AcsAccessGroupFrom|null
@@ -122,14 +201,32 @@ class AcsAccessGroupFrom
     }
 
     public function __construct(
+        /**
+         * Old entrance ID.
+         */
         public string|null $acs_entrance_id,
+        /**
+         * Old user ID.
+         */
         public string|null $acs_user_id,
+        /**
+         * Ending time for the access schedule.
+         */
         public string|null $ends_at,
+        /**
+         * Name of the access group.
+         */
         public string|null $name,
+        /**
+         * Starting time for the access schedule.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Collection of pending mutations for the access group. Represents operations that have been requested but not yet completed on the integrated access system.
+ */
 class AcsAccessGroupPendingMutations
 {
     public static function from_json(
@@ -154,16 +251,40 @@ class AcsAccessGroupPendingMutations
     }
 
     public function __construct(
+        /**
+         * ID of the user involved in the scheduled change.
+         */
         public string|null $acs_user_id,
+        /**
+         * Date and time at which the mutation was created.
+         */
         public string|null $created_at,
+        /**
+         * Old access group information.
+         */
         public AcsAccessGroupFrom|null $from,
+        /**
+         * Detailed description of the mutation.
+         */
         public string|null $message,
+        /**
+         * Mutation code to indicate that Seam is in the process of pushing an access group creation to the integrated access system.
+         */
         public string|null $mutation_code,
+        /**
+         * New access group information.
+         */
         public AcsAccessGroupTo|null $to,
+        /**
+         * Whether the user is scheduled to be added to or removed from this access group.
+         */
         public string|null $variant,
     ) {}
 }
 
+/**
+ * New access group information.
+ */
 class AcsAccessGroupTo
 {
     public static function from_json(mixed $json): AcsAccessGroupTo|null
@@ -181,14 +302,32 @@ class AcsAccessGroupTo
     }
 
     public function __construct(
+        /**
+         * New entrance ID.
+         */
         public string|null $acs_entrance_id,
+        /**
+         * New user ID.
+         */
         public string|null $acs_user_id,
+        /**
+         * Ending time for the access schedule.
+         */
         public string|null $ends_at,
+        /**
+         * Name of the access group.
+         */
         public string|null $name,
+        /**
+         * Starting time for the access schedule.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Warnings associated with the `acs_access_group`.
+ */
 class AcsAccessGroupWarnings
 {
     public static function from_json(mixed $json): AcsAccessGroupWarnings|null
@@ -204,8 +343,17 @@ class AcsAccessGroupWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/AcsCredential.php
+++ b/src/Resources/AcsCredential.php
@@ -2,6 +2,15 @@
 
 namespace Seam\Resources;
 
+/**
+ * Means by which an [access control system user](https://docs.seam.co/low-level-apis/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+ *
+ * An access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.
+ *
+ * For each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.
+ *
+ * For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach. Use the lower-level ACS credential API directly only when you specifically need to manage individual credentials.
+ */
 class AcsCredential
 {
     public static function from_json(mixed $json): AcsCredential|null
@@ -60,37 +69,124 @@ class AcsCredential
     }
 
     public function __construct(
+        /**
+         * Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+         */
         public string|null $access_method,
+        /**
+         * ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $acs_credential_id,
+        /**
+         * ID of the credential pool to which the credential belongs.
+         */
         public string|null $acs_credential_pool_id,
+        /**
+         * ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $acs_system_id,
+        /**
+         * ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+         */
         public string|null $acs_user_id,
+        /**
+         * Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public AcsCredentialAssaAbloyVostioMetadata|null $assa_abloy_vostio_metadata,
+        /**
+         * Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $card_number,
+        /**
+         * Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $code,
+        /**
+         * ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name that corresponds to the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+         */
         public string|null $display_name,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+         */
         public string|null $ends_at,
+        /**
+         * Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public array $errors,
+        /**
+         * Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+         */
         public string|null $external_type,
+        /**
+         * Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+         */
         public string|null $external_type_display_name,
+        /**
+         * Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been encoded onto a card.
+         */
         public bool|null $is_issued,
+        /**
+         * Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
+         */
         public bool|null $is_latest_desired_state_synced_with_provider,
+        /**
+         * Indicates whether Seam manages the credential.
+         */
         public bool|null $is_managed,
+        /**
+         * Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+         */
         public bool|null $is_multi_phone_sync_credential,
+        /**
+         * Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
+         */
         public bool|null $is_one_time_use,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was encoded onto a card.
+         */
         public string|null $issued_at,
+        /**
+         * Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
+         */
         public string|null $latest_desired_state_synced_with_provider_at,
+        /**
+         * ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $parent_acs_credential_id,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $starts_at,
+        /**
+         * ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+         */
         public string|null $user_identity_id,
+        /**
+         * Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public AcsCredentialVisionlineMetadata|null $visionline_metadata,
+        /**
+         * Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public array $warnings,
+        /**
+         * ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+ */
 class AcsCredentialAssaAbloyVostioMetadata
 {
     public static function from_json(
@@ -111,15 +207,36 @@ class AcsCredentialAssaAbloyVostioMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+         */
         public bool|null $auto_join,
+        /**
+         * Names of the doors to which to grant access in the Vostio access system.
+         */
         public array|null $door_names,
+        /**
+         * Endpoint ID in the Vostio access system.
+         */
         public string|null $endpoint_id,
+        /**
+         * Key ID in the Vostio access system.
+         */
         public string|null $key_id,
+        /**
+         * Key issuing request ID in the Vostio access system.
+         */
         public string|null $key_issuing_request_id,
+        /**
+         * IDs of the guest entrances to override in the Vostio access system.
+         */
         public array|null $override_guest_acs_entrance_ids,
     ) {}
 }
 
+/**
+ * Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+ */
 class AcsCredentialErrors
 {
     public static function from_json(mixed $json): AcsCredentialErrors|null
@@ -135,12 +252,18 @@ class AcsCredentialErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
         public string|null $error_code,
         public string|null $message,
     ) {}
 }
 
+/**
+ * Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+ */
 class AcsCredentialVisionlineMetadata
 {
     public static function from_json(
@@ -162,17 +285,44 @@ class AcsCredentialVisionlineMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+         */
         public bool|null $auto_join,
+        /**
+         * Card function type in the Visionline access system.
+         */
         public string|null $card_function_type,
+        /**
+         * ID of the card in the Visionline access system.
+         */
         public string|null $card_id,
+        /**
+         * Common entrance IDs in the Visionline access system.
+         */
         public array|null $common_acs_entrance_ids,
+        /**
+         * ID of the credential in the Visionline access system.
+         */
         public string|null $credential_id,
+        /**
+         * Guest entrance IDs in the Visionline access system.
+         */
         public array|null $guest_acs_entrance_ids,
+        /**
+         * Indicates whether the credential is valid.
+         */
         public bool|null $is_valid,
+        /**
+         * IDs of the credentials to which you want to join.
+         */
         public array|null $joiner_acs_credential_ids,
     ) {}
 }
 
+/**
+ * Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+ */
 class AcsCredentialWarnings
 {
     public static function from_json(mixed $json): AcsCredentialWarnings|null
@@ -188,8 +338,17 @@ class AcsCredentialWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/AcsEncoder.php
+++ b/src/Resources/AcsEncoder.php
@@ -2,6 +2,22 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a hardware device that encodes [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) data onto physical cards within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+ *
+ * Some access control systems require credentials to be encoded onto plastic key cards using a card encoder. This process involves the following two key steps:
+ *
+ * 1. Credential creation
+ *    Configure the access parameters for the credential.
+ * 2. Card encoding
+ *    Write the credential data onto the card using a compatible card encoder.
+ *
+ * Separately, the Seam API also supports card scanning, which enables you to scan and read the encoded data on a card. You can use this action to confirm consistency with access control system records or diagnose discrepancies if needed.
+ *
+ * See [Working with Card Encoders and Scanners](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+ *
+ * To verify if your access control system requires a card encoder, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+ */
 class AcsEncoder
 {
     public static function from_json(mixed $json): AcsEncoder|null
@@ -24,16 +40,40 @@ class AcsEncoder
     }
 
     public function __construct(
+        /**
+         * ID of the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+         */
         public string|null $acs_encoder_id,
+        /**
+         * ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+         */
         public string|null $acs_system_id,
+        /**
+         * ID of the connected account that contains the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name for the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+         */
         public string|null $display_name,
+        /**
+         * Errors associated with the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+         */
         public array $errors,
+        /**
+         * ID of the workspace that contains the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Errors associated with the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+ */
 class AcsEncoderErrors
 {
     public static function from_json(mixed $json): AcsEncoderErrors|null
@@ -49,8 +89,17 @@ class AcsEncoderErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }

--- a/src/Resources/AcsEntrance.php
+++ b/src/Resources/AcsEntrance.php
@@ -2,6 +2,11 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+ *
+ * In an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the `acs_entrance` resources in your workspace or get these details for a specific `acs_entrance`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.
+ */
 class AcsEntrance
 {
     public static function from_json(mixed $json): AcsEntrance|null
@@ -86,34 +91,112 @@ class AcsEntrance
     }
 
     public function __construct(
+        /**
+         * ID of the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public string|null $acs_entrance_id,
+        /**
+         * ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public string|null $acs_system_id,
+        /**
+         * Akiles-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceAkilesMetadata|null $akiles_metadata,
+        /**
+         * ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceAssaAbloyVostioMetadata|null $assa_abloy_vostio_metadata,
+        /**
+         * Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceAvigilonAltaMetadata|null $avigilon_alta_metadata,
+        /**
+         * Brivo-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceBrivoMetadata|null $brivo_metadata,
+        /**
+         * Indicates whether the ACS entrance can belong to a reservation via an access_grant.reservation_key.
+         */
         public bool|null $can_belong_to_reservation,
+        /**
+         * Indicates whether the ACS entrance can be unlocked with card credentials.
+         */
         public bool|null $can_unlock_with_card,
+        /**
+         * Indicates whether the ACS entrance can be unlocked with cloud key credentials.
+         */
         public bool|null $can_unlock_with_cloud_key,
+        /**
+         * Indicates whether the ACS entrance can be unlocked with pin codes.
+         */
         public bool|null $can_unlock_with_code,
+        /**
+         * Indicates whether the ACS entrance can be unlocked with mobile key credentials.
+         */
         public bool|null $can_unlock_with_mobile_key,
+        /**
+         * ID of the [connected account](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name for the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public string|null $display_name,
+        /**
+         * dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceDormakabaAmbianceMetadata|null $dormakaba_ambiance_metadata,
+        /**
+         * dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceDormakabaCommunityMetadata|null $dormakaba_community_metadata,
+        /**
+         * Errors associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public array $errors,
+        /**
+         * Hotek-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceHotekMetadata|null $hotek_metadata,
+        /**
+         * Indicates whether the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) is currently locked.
+         */
         public bool|null $is_locked,
+        /**
+         * Latch-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceLatchMetadata|null $latch_metadata,
+        /**
+         * Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceSaltoKsMetadata|null $salto_ks_metadata,
+        /**
+         * Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceSaltoSpaceMetadata|null $salto_space_metadata,
+        /**
+         * IDs of the spaces that the entrance is in.
+         */
         public array|null $space_ids,
+        /**
+         * Visionline-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public AcsEntranceVisionlineMetadata|null $visionline_metadata,
+        /**
+         * Warnings associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public array $warnings,
     ) {}
 }
 
+/**
+ * Actions the gadget exposes (for example, open).
+ */
 class AcsEntranceActions
 {
     public static function from_json(mixed $json): AcsEntranceActions|null
@@ -125,11 +208,20 @@ class AcsEntranceActions
     }
 
     public function __construct(
+        /**
+         * ID of the gadget action.
+         */
         public string|null $id,
+        /**
+         * Name of the gadget action.
+         */
         public string|null $name,
     ) {}
 }
 
+/**
+ * Akiles-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceAkilesMetadata
 {
     public static function from_json(
@@ -150,13 +242,28 @@ class AcsEntranceAkilesMetadata
     }
 
     public function __construct(
+        /**
+         * Actions the gadget exposes (for example, open).
+         */
         public array $actions,
+        /**
+         * ID of the Akiles gadget.
+         */
         public string|null $gadget_id,
+        /**
+         * ID of the Akiles site the gadget belongs to.
+         */
         public string|null $site_id,
+        /**
+         * Name of the Akiles site the gadget belongs to.
+         */
         public string|null $site_name,
     ) {}
 }
 
+/**
+ * ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceAssaAbloyVostioMetadata
 {
     public static function from_json(
@@ -175,14 +282,32 @@ class AcsEntranceAssaAbloyVostioMetadata
     }
 
     public function __construct(
+        /**
+         * Name of the door in the Vostio access system.
+         */
         public string|null $door_name,
+        /**
+         * Number of the door in the Vostio access system.
+         */
         public float|null $door_number,
+        /**
+         * Type of the door in the Vostio access system.
+         */
         public string|null $door_type,
+        /**
+         * PMS ID of the door in the Vostio access system.
+         */
         public string|null $pms_id,
+        /**
+         * Indicates whether keys are allowed to set the door in stand open mode in the Vostio access system.
+         */
         public bool|null $stand_open,
     ) {}
 }
 
+/**
+ * Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceAvigilonAltaMetadata
 {
     public static function from_json(
@@ -203,16 +328,40 @@ class AcsEntranceAvigilonAltaMetadata
     }
 
     public function __construct(
+        /**
+         * Entry name for an Avigilon Alta system.
+         */
         public string|null $entry_name,
+        /**
+         * Total count of entry relays for an Avigilon Alta system.
+         */
         public float|null $entry_relays_total_count,
+        /**
+         * Organization name for an Avigilon Alta system.
+         */
         public string|null $org_name,
+        /**
+         * Site ID for an Avigilon Alta system.
+         */
         public float|null $site_id,
+        /**
+         * Site name for an Avigilon Alta system.
+         */
         public string|null $site_name,
+        /**
+         * Zone ID for an Avigilon Alta system.
+         */
         public float|null $zone_id,
+        /**
+         * Zone name for an Avigilon Alta system.
+         */
         public string|null $zone_name,
     ) {}
 }
 
+/**
+ * Brivo-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceBrivoMetadata
 {
     public static function from_json(mixed $json): AcsEntranceBrivoMetadata|null
@@ -228,12 +377,24 @@ class AcsEntranceBrivoMetadata
     }
 
     public function __construct(
+        /**
+         * ID of the access point in the Brivo access system.
+         */
         public string|null $access_point_id,
+        /**
+         * ID of the site that the access point belongs to.
+         */
         public float|null $site_id,
+        /**
+         * Name of the site that the access point belongs to.
+         */
         public string|null $site_name,
     ) {}
 }
 
+/**
+ * dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceDormakabaAmbianceMetadata
 {
     public static function from_json(
@@ -245,9 +406,17 @@ class AcsEntranceDormakabaAmbianceMetadata
         return new self(access_point_name: $json->access_point_name ?? null);
     }
 
-    public function __construct(public string|null $access_point_name) {}
+    public function __construct(
+        /**
+         * Name of the access point in the dormakaba Ambiance access system.
+         */
+        public string|null $access_point_name,
+    ) {}
 }
 
+/**
+ * dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceDormakabaCommunityMetadata
 {
     public static function from_json(
@@ -261,9 +430,17 @@ class AcsEntranceDormakabaCommunityMetadata
         );
     }
 
-    public function __construct(public string|null $access_point_profile) {}
+    public function __construct(
+        /**
+         * Type of access point profile in the dormakaba Community access system.
+         */
+        public string|null $access_point_profile,
+    ) {}
 }
 
+/**
+ * Errors associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceErrors
 {
     public static function from_json(mixed $json): AcsEntranceErrors|null
@@ -279,12 +456,24 @@ class AcsEntranceErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Hotek-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceHotekMetadata
 {
     public static function from_json(mixed $json): AcsEntranceHotekMetadata|null
@@ -300,12 +489,24 @@ class AcsEntranceHotekMetadata
     }
 
     public function __construct(
+        /**
+         * Display name of the entrance.
+         */
         public string|null $common_area_name,
+        /**
+         * Display name of the entrance.
+         */
         public string|null $common_area_number,
+        /**
+         * Room number of the entrance.
+         */
         public string|null $room_number,
     ) {}
 }
 
+/**
+ * Latch-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceLatchMetadata
 {
     public static function from_json(mixed $json): AcsEntranceLatchMetadata|null
@@ -322,13 +523,28 @@ class AcsEntranceLatchMetadata
     }
 
     public function __construct(
+        /**
+         * Accessibility type in the Latch access system.
+         */
         public string|null $accessibility_type,
+        /**
+         * Name of the door in the Latch access system.
+         */
         public string|null $door_name,
+        /**
+         * Type of the door in the Latch access system.
+         */
         public string|null $door_type,
+        /**
+         * Indicates whether the entrance is connected.
+         */
         public bool|null $is_connected,
     ) {}
 }
 
+/**
+ * Profile for the door in the Visionline access system.
+ */
 class AcsEntranceProfiles
 {
     public static function from_json(mixed $json): AcsEntranceProfiles|null
@@ -345,11 +561,20 @@ class AcsEntranceProfiles
     }
 
     public function __construct(
+        /**
+         * Door profile ID in the Visionline access system.
+         */
         public string|null $visionline_door_profile_id,
+        /**
+         * Door profile type in the Visionline access system.
+         */
         public string|null $visionline_door_profile_type,
     ) {}
 }
 
+/**
+ * Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceSaltoKsMetadata
 {
     public static function from_json(
@@ -371,17 +596,44 @@ class AcsEntranceSaltoKsMetadata
     }
 
     public function __construct(
+        /**
+         * Battery level of the door access device.
+         */
         public string|null $battery_level,
+        /**
+         * Name of the door in the Salto KS access system.
+         */
         public string|null $door_name,
+        /**
+         * Indicates whether an intrusion alarm is active on the door.
+         */
         public bool|null $intrusion_alarm,
+        /**
+         * Indicates whether the door is left open.
+         */
         public bool|null $left_open_alarm,
+        /**
+         * Type of the lock in the Salto KS access system.
+         */
         public string|null $lock_type,
+        /**
+         * Locked state of the door in the Salto KS access system.
+         */
         public string|null $locked_state,
+        /**
+         * Indicates whether the door access device is online.
+         */
         public bool|null $online,
+        /**
+         * Indicates whether privacy mode is enabled for the lock.
+         */
         public bool|null $privacy_mode,
     ) {}
 }
 
+/**
+ * Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceSaltoSpaceMetadata
 {
     public static function from_json(
@@ -401,15 +653,36 @@ class AcsEntranceSaltoSpaceMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether AuditOnKeys is enabled for the door in the Salto Space access system.
+         */
         public bool|null $audit_on_keys,
+        /**
+         * Description of the door in the Salto Space access system.
+         */
         public string|null $door_description,
+        /**
+         * Door ID in the Salto Space access system.
+         */
         public string|null $door_id,
+        /**
+         * Name of the door in the Salto Space access system.
+         */
         public string|null $door_name,
+        /**
+         * Description of the room in the Salto Space access system.
+         */
         public string|null $room_description,
+        /**
+         * Name of the room in the Salto Space access system.
+         */
         public string|null $room_name,
     ) {}
 }
 
+/**
+ * Visionline-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceVisionlineMetadata
 {
     public static function from_json(
@@ -429,12 +702,24 @@ class AcsEntranceVisionlineMetadata
     }
 
     public function __construct(
+        /**
+         * Category of the door in the Visionline access system.
+         */
         public string|null $door_category,
+        /**
+         * Name of the door in the Visionline access system.
+         */
         public string|null $door_name,
+        /**
+         * Profile for the door in the Visionline access system.
+         */
         public array $profiles,
     ) {}
 }
 
+/**
+ * Warnings associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+ */
 class AcsEntranceWarnings
 {
     public static function from_json(mixed $json): AcsEntranceWarnings|null
@@ -450,8 +735,17 @@ class AcsEntranceWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/AcsSystem.php
+++ b/src/Resources/AcsSystem.php
@@ -2,6 +2,13 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+ *
+ * Within an `acs_system`, create [`acs_user`s](https://docs.seam.co/api/acs/users/object) and [`acs_credential`s](https://docs.seam.co/api/acs/credentials/object) to grant access to the `acs_user`s.
+ *
+ * For details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/api/acs).
+ */
 class AcsSystem
 {
     public static function from_json(mixed $json): AcsSystem|null
@@ -48,29 +55,94 @@ class AcsSystem
     }
 
     public function __construct(
+        /**
+         * Number of access groups in the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public float|null $acs_access_group_count,
+        /**
+         * ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public string|null $acs_system_id,
+        /**
+         * Number of users in the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public float|null $acs_user_count,
+        /**
+         * ID of the connected account associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public string|null $connected_account_id,
+        /**
+         * IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         *
+         * @deprecated Use `connected_account_id`.
+         */
         public array|null $connected_account_ids,
+        /**
+         * Date and time at which the [access control system](https://docs.seam.co/low-level-apis/access-systems) was created.
+         */
         public string|null $created_at,
+        /**
+         * ID of the default credential manager `acs_system` for this [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public string|null $default_credential_manager_acs_system_id,
+        /**
+         * Errors associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public array $errors,
+        /**
+         * Brand-specific terminology for the [access control system](https://docs.seam.co/low-level-apis/access-systems) type.
+         */
         public string|null $external_type,
+        /**
+         * Display name that corresponds to the brand-specific terminology for the [access control system](https://docs.seam.co/low-level-apis/access-systems) type.
+         */
         public string|null $external_type_display_name,
+        /**
+         * Alternative text for the [access control system](https://docs.seam.co/low-level-apis/access-systems) image.
+         */
         public string|null $image_alt_text,
+        /**
+         * URL for the image that represents the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public string|null $image_url,
+        /**
+         * Indicates whether the `acs_system` is a credential manager.
+         */
         public bool|null $is_credential_manager,
+        /**
+         * Location information for the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public AcsSystemLocation|null $location,
+        /**
+         * Name of the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public string|null $name,
+        /**
+         * @deprecated Use `external_type`.
+         */
         public string|null $system_type,
+        /**
+         * @deprecated Use `external_type_display_name`.
+         */
         public string|null $system_type_display_name,
+        /**
+         * Visionline-specific metadata for the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public AcsSystemVisionlineMetadata|null $visionline_metadata,
+        /**
+         * Warnings associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public array $warnings,
+        /**
+         * ID of the workspace that contains the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Errors associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+ */
 class AcsSystemErrors
 {
     public static function from_json(mixed $json): AcsSystemErrors|null
@@ -87,13 +159,28 @@ class AcsSystemErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Indicates whether the error is related to the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+         */
         public bool|null $is_bridge_error,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Location information for the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+ */
 class AcsSystemLocation
 {
     public static function from_json(mixed $json): AcsSystemLocation|null
@@ -104,9 +191,17 @@ class AcsSystemLocation
         return new self(time_zone: $json->time_zone ?? null);
     }
 
-    public function __construct(public string|null $time_zone) {}
+    public function __construct(
+        /**
+         * Time zone in which the [access control system](https://docs.seam.co/low-level-apis/access-systems) is located.
+         */
+        public string|null $time_zone,
+    ) {}
 }
 
+/**
+ * Visionline-specific metadata for the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+ */
 class AcsSystemVisionlineMetadata
 {
     public static function from_json(
@@ -123,12 +218,24 @@ class AcsSystemVisionlineMetadata
     }
 
     public function __construct(
+        /**
+         * IP address or hostname of the main Visionline server relative to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) on the local network.
+         */
         public string|null $lan_address,
+        /**
+         * Keyset loaded into a reader. Mobile keys and reader administration tools securely authenticate only with readers programmed with a matching keyset.
+         */
         public string|null $mobile_access_uuid,
+        /**
+         * Unique ID assigned by the ASSA ABLOY licensing team that identifies each hotel in your credential manager.
+         */
         public string|null $system_id,
     ) {}
 }
 
+/**
+ * Warnings associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+ */
 class AcsSystemWarnings
 {
     public static function from_json(mixed $json): AcsSystemWarnings|null
@@ -146,9 +253,21 @@ class AcsSystemWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * @deprecated this field is deprecated.
+         */
         public array|null $misconfigured_acs_entrance_ids,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/AcsUser.php
+++ b/src/Resources/AcsUser.php
@@ -2,6 +2,13 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a [user](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access system](https://docs.seam.co/low-level-apis/access-systems).
+ *
+ * An access system user typically refers to an individual who requires access, like an employee or resident. Each user can possess multiple credentials that serve as their keys or identifiers for access. The type of credential can vary widely. For example, in the Salto system, a user can have a PIN code, a mobile app account, and a fob. In other platforms, it is not uncommon for a user to have more than one of the same credential type, such as multiple key cards. Additionally, these credentials can have a schedule or validity period.
+ *
+ * For details about how to configure users in your access system, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+ */
 class AcsUser
 {
     public static function from_json(mixed $json): AcsUser|null
@@ -59,34 +66,112 @@ class AcsUser
     }
 
     public function __construct(
+        /**
+         * `starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/low-level-apis/access-systems/user-management) access.
+         */
         public AcsUserAccessSchedule|null $access_schedule,
+        /**
+         * ID of the [access system](https://docs.seam.co/low-level-apis/access-systems) that contains the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $acs_system_id,
+        /**
+         * ID of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $acs_user_id,
+        /**
+         * The ID of the connected account that is associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name for the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $display_name,
+        /**
+         * @deprecated use email_address.
+         */
         public string|null $email,
+        /**
+         * Email address of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $email_address,
+        /**
+         * Errors associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public array $errors,
+        /**
+         * Brand-specific terminology for the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) type.
+         */
         public string|null $external_type,
+        /**
+         * Display name that corresponds to the brand-specific terminology for the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) type.
+         */
         public string|null $external_type_display_name,
+        /**
+         * Full name of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $full_name,
+        /**
+         * ID of the HID access control system associated with the user.
+         */
         public string|null $hid_acs_system_id,
+        /**
+         * Indicates whether Seam manages the access system user.
+         */
         public bool|null $is_managed,
+        /**
+         * Indicates whether the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) is currently [suspended](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users).
+         */
         public bool|null $is_suspended,
+        /**
+         * Pending mutations associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.
+         */
         public array $pending_mutations,
+        /**
+         * Phone number of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
+         */
         public string|null $phone_number,
+        /**
+         * Salto KS-specific metadata associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public AcsUserSaltoKsMetadata|null $salto_ks_metadata,
+        /**
+         * Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public AcsUserSaltoSpaceMetadata|null $salto_space_metadata,
+        /**
+         * Email address of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $user_identity_email_address,
+        /**
+         * Full name of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $user_identity_full_name,
+        /**
+         * ID of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $user_identity_id,
+        /**
+         * Phone number of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
+         */
         public string|null $user_identity_phone_number,
+        /**
+         * Warnings associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public array $warnings,
+        /**
+         * ID of the workspace that contains the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * `starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/low-level-apis/access-systems/user-management) access.
+ */
 class AcsUserAccessSchedule
 {
     public static function from_json(mixed $json): AcsUserAccessSchedule|null
@@ -101,11 +186,20 @@ class AcsUserAccessSchedule
     }
 
     public function __construct(
+        /**
+         * Date and time at which the user's access ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $ends_at,
+        /**
+         * Date and time at which the user's access starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Errors associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+ */
 class AcsUserErrors
 {
     public static function from_json(mixed $json): AcsUserErrors|null
@@ -121,12 +215,21 @@ class AcsUserErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Old access system user information.
+ */
 class AcsUserFrom
 {
     public static function from_json(mixed $json): AcsUserFrom|null
@@ -147,17 +250,41 @@ class AcsUserFrom
     }
 
     public function __construct(
+        /**
+         * Old access group ID.
+         */
         public string|null $acs_access_group_id,
+        /**
+         * Previous credential ID.
+         */
         public string|null $acs_credential_id,
+        /**
+         * Email address of the access system user.
+         */
         public string|null $email_address,
+        /**
+         * Starting time for the access schedule.
+         */
         public string|null $ends_at,
+        /**
+         * Full name of the access system user.
+         */
         public string|null $full_name,
         public bool|null $is_suspended,
+        /**
+         * Phone number of the access system user.
+         */
         public string|null $phone_number,
+        /**
+         * Starting time for the access schedule.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Pending mutations associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.
+ */
 class AcsUserPendingMutations
 {
     public static function from_json(mixed $json): AcsUserPendingMutations|null
@@ -180,17 +307,44 @@ class AcsUserPendingMutations
     }
 
     public function __construct(
+        /**
+         * ID of the access group involved in the scheduled change.
+         */
         public string|null $acs_access_group_id,
+        /**
+         * Date and time at which the mutation was created.
+         */
         public string|null $created_at,
+        /**
+         * Old access system user information.
+         */
         public AcsUserFrom|null $from,
+        /**
+         * Detailed description of the mutation.
+         */
         public string|null $message,
+        /**
+         * Mutation code to indicate that Seam is in the process of pushing a user creation to the integrated access system.
+         */
         public string|null $mutation_code,
+        /**
+         * Optional: When the user creation is scheduled to occur.
+         */
         public string|null $scheduled_at,
+        /**
+         * New access system user information.
+         */
         public AcsUserTo|null $to,
+        /**
+         * Whether the user is scheduled to be added to or removed from the access group.
+         */
         public string|null $variant,
     ) {}
 }
 
+/**
+ * Salto KS-specific metadata associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+ */
 class AcsUserSaltoKsMetadata
 {
     public static function from_json(mixed $json): AcsUserSaltoKsMetadata|null
@@ -201,9 +355,17 @@ class AcsUserSaltoKsMetadata
         return new self(is_subscribed: $json->is_subscribed ?? null);
     }
 
-    public function __construct(public bool|null $is_subscribed) {}
+    public function __construct(
+        /**
+         * Indicates whether the user holds an active subscription slot on the Salto KS site. Only subscribed users can unlock doors and count against the site's user-subscription limit. A user may not be subscribed because their access schedule has not started or has ended, the site has reached its subscription limit, or they were manually unsubscribed. This is distinct from `is_suspended`, which reflects whether the user has been explicitly blocked.
+         */
+        public bool|null $is_subscribed,
+    ) {}
 }
 
+/**
+ * Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+ */
 class AcsUserSaltoSpaceMetadata
 {
     public static function from_json(
@@ -219,11 +381,20 @@ class AcsUserSaltoSpaceMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether AuditOpenings is enabled for the user in the Salto Space access system.
+         */
         public bool|null $audit_openings,
+        /**
+         * User ID in the Salto Space access system.
+         */
         public string|null $user_id,
     ) {}
 }
 
+/**
+ * New access system user information.
+ */
 class AcsUserTo
 {
     public static function from_json(mixed $json): AcsUserTo|null
@@ -244,17 +415,41 @@ class AcsUserTo
     }
 
     public function __construct(
+        /**
+         * New access group ID.
+         */
         public string|null $acs_access_group_id,
+        /**
+         * New credential ID.
+         */
         public string|null $acs_credential_id,
+        /**
+         * Email address of the access system user.
+         */
         public string|null $email_address,
+        /**
+         * Starting time for the access schedule.
+         */
         public string|null $ends_at,
+        /**
+         * Full name of the access system user.
+         */
         public string|null $full_name,
         public bool|null $is_suspended,
+        /**
+         * Phone number of the access system user.
+         */
         public string|null $phone_number,
+        /**
+         * Starting time for the access schedule.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Warnings associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+ */
 class AcsUserWarnings
 {
     public static function from_json(mixed $json): AcsUserWarnings|null
@@ -270,7 +465,13 @@ class AcsUserWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
         public string|null $warning_code,
     ) {}

--- a/src/Resources/ActionAttempt.php
+++ b/src/Resources/ActionAttempt.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Locking a door is pending.
+ */
 class ActionAttempt
 {
     public static function from_json(mixed $json): ActionAttempt|null
@@ -23,14 +26,29 @@ class ActionAttempt
     }
 
     public function __construct(
+        /**
+         * ID of the action attempt.
+         */
         public string|null $action_attempt_id,
+        /**
+         * Action attempt to track the status of locking a door.
+         */
         public string|null $action_type,
+        /**
+         * Error associated with the action.
+         */
         public ActionAttemptError|null $error,
+        /**
+         * Result of the action.
+         */
         public ActionAttemptResult|null $result,
         public string|null $status,
     ) {}
 }
 
+/**
+ * Snapshot of credential data read from the physical encoder.
+ */
 class ActionAttemptAcsCredentialOnEncoder
 {
     public static function from_json(
@@ -54,15 +72,36 @@ class ActionAttemptAcsCredentialOnEncoder
     }
 
     public function __construct(
+        /**
+         * A number or string that physically identifies the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $card_number,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+         */
         public string|null $created_at,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) will stop being usable.
+         */
         public string|null $ends_at,
+        /**
+         * Indicates whether the credential has been issued (encoded onto a card).
+         */
         public bool|null $is_issued,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) becomes usable.
+         */
         public string|null $starts_at,
+        /**
+         * Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public ActionAttemptVisionlineMetadata|null $visionline_metadata,
     ) {}
 }
 
+/**
+ * Corresponding credential data as stored on Seam and the access system.
+ */
 class ActionAttemptAcsCredentialOnSeam
 {
     public static function from_json(
@@ -122,37 +161,121 @@ class ActionAttemptAcsCredentialOnSeam
     }
 
     public function __construct(
+        /**
+         * Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+         */
         public string|null $access_method,
+        /**
+         * ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $acs_credential_id,
+        /**
+         * ID of the credential pool to which the credential belongs.
+         */
         public string|null $acs_credential_pool_id,
+        /**
+         * ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $acs_system_id,
+        /**
+         * ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+         */
         public string|null $acs_user_id,
+        /**
+         * Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public ActionAttemptAssaAbloyVostioMetadata|null $assa_abloy_vostio_metadata,
+        /**
+         * Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $card_number,
+        /**
+         * Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $code,
+        /**
+         * ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name that corresponds to the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+         */
         public string|null $display_name,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+         */
         public string|null $ends_at,
+        /**
+         * Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public array $errors,
+        /**
+         * Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+         */
         public string|null $external_type,
+        /**
+         * Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+         */
         public string|null $external_type_display_name,
+        /**
+         * Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been encoded onto a card.
+         */
         public bool|null $is_issued,
+        /**
+         * Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
+         */
         public bool|null $is_latest_desired_state_synced_with_provider,
         public bool|null $is_managed,
+        /**
+         * Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+         */
         public bool|null $is_multi_phone_sync_credential,
+        /**
+         * Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
+         */
         public bool|null $is_one_time_use,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was encoded onto a card.
+         */
         public string|null $issued_at,
+        /**
+         * Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
+         */
         public string|null $latest_desired_state_synced_with_provider_at,
+        /**
+         * ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $parent_acs_credential_id,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $starts_at,
+        /**
+         * ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+         */
         public string|null $user_identity_id,
+        /**
+         * Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public ActionAttemptVisionlineMetadata|null $visionline_metadata,
+        /**
+         * Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public array $warnings,
+        /**
+         * ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+ */
 class ActionAttemptAssaAbloyVostioMetadata
 {
     public static function from_json(
@@ -173,15 +296,36 @@ class ActionAttemptAssaAbloyVostioMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+         */
         public bool|null $auto_join,
+        /**
+         * Names of the doors to which to grant access in the Vostio access system.
+         */
         public array|null $door_names,
+        /**
+         * Endpoint ID in the Vostio access system.
+         */
         public string|null $endpoint_id,
+        /**
+         * Key ID in the Vostio access system.
+         */
         public string|null $key_id,
+        /**
+         * Key issuing request ID in the Vostio access system.
+         */
         public string|null $key_issuing_request_id,
+        /**
+         * IDs of the guest entrances to override in the Vostio access system.
+         */
         public array|null $override_guest_acs_entrance_ids,
     ) {}
 }
 
+/**
+ * Error associated with the action.
+ */
 class ActionAttemptError
 {
     public static function from_json(mixed $json): ActionAttemptError|null
@@ -196,11 +340,20 @@ class ActionAttemptError
     }
 
     public function __construct(
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Type of the error.
+         */
         public string|null $type,
     ) {}
 }
 
+/**
+ * Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+ */
 class ActionAttemptErrors
 {
     public static function from_json(mixed $json): ActionAttemptErrors|null
@@ -216,12 +369,18 @@ class ActionAttemptErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
         public string|null $error_code,
         public string|null $message,
     ) {}
 }
 
+/**
+ * Previous access time configuration.
+ */
 class ActionAttemptFrom
 {
     public static function from_json(mixed $json): ActionAttemptFrom|null
@@ -236,11 +395,20 @@ class ActionAttemptFrom
     }
 
     public function __construct(
+        /**
+         * Previous end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * Previous start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
+ */
 class ActionAttemptPendingMutations
 {
     public static function from_json(
@@ -261,14 +429,32 @@ class ActionAttemptPendingMutations
     }
 
     public function __construct(
+        /**
+         * Date and time at which the mutation was created.
+         */
         public string|null $created_at,
+        /**
+         * Previous access time configuration.
+         */
         public ActionAttemptFrom|null $from,
+        /**
+         * Detailed description of the mutation.
+         */
         public string|null $message,
+        /**
+         * Mutation code to indicate that Seam is in the process of updating the access times for this access method.
+         */
         public string|null $mutation_code,
+        /**
+         * New access time configuration.
+         */
         public ActionAttemptTo|null $to,
     ) {}
 }
 
+/**
+ * Result of the action.
+ */
 class ActionAttemptResult
 {
     public static function from_json(mixed $json): ActionAttemptResult|null
@@ -351,50 +537,173 @@ class ActionAttemptResult
     }
 
     public function __construct(
+        /**
+         * Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+         */
         public string|null $access_method,
+        /**
+         * ID of the access method.
+         */
         public string|null $access_method_id,
+        /**
+         * ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $acs_credential_id,
+        /**
+         * Snapshot of credential data read from the physical encoder.
+         */
         public ActionAttemptAcsCredentialOnEncoder|null $acs_credential_on_encoder,
+        /**
+         * Corresponding credential data as stored on Seam and the access system.
+         */
         public ActionAttemptAcsCredentialOnSeam|null $acs_credential_on_seam,
+        /**
+         * ID of the credential pool to which the credential belongs.
+         */
         public string|null $acs_credential_pool_id,
+        /**
+         * ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $acs_system_id,
+        /**
+         * ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+         */
         public string|null $acs_user_id,
+        /**
+         * Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public ActionAttemptAssaAbloyVostioMetadata|null $assa_abloy_vostio_metadata,
+        /**
+         * Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $card_number,
+        /**
+         * Token of the client session associated with the access method.
+         */
         public string|null $client_session_token,
+        /**
+         * Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $code,
+        /**
+         * ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+         */
         public string|null $created_at,
+        /**
+         * ID of the customization profile associated with the access method.
+         */
         public string|null $customization_profile_id,
+        /**
+         * Display name that corresponds to the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+         */
         public string|null $display_name,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+         */
         public string|null $ends_at,
+        /**
+         * Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public array $errors,
+        /**
+         * Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+         */
         public string|null $external_type,
+        /**
+         * Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+         */
         public string|null $external_type_display_name,
+        /**
+         * URL of the Instant Key for mobile key access methods.
+         */
         public string|null $instant_key_url,
+        /**
+         * Indicates whether an existing card credential must be assigned to this access method before it can be issued. Only applies to card-mode access methods on systems that support credential assignment.
+         */
         public bool|null $is_assignment_required,
+        /**
+         * Indicates whether encoding with an card encoder is required to issue or reissue the plastic card associated with the access method.
+         */
         public bool|null $is_encoding_required,
+        /**
+         * Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been encoded onto a card.
+         */
         public bool|null $is_issued,
+        /**
+         * Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
+         */
         public bool|null $is_latest_desired_state_synced_with_provider,
         public bool|null $is_managed,
+        /**
+         * Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+         */
         public bool|null $is_multi_phone_sync_credential,
+        /**
+         * Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
+         */
         public bool|null $is_one_time_use,
+        /**
+         * Indicates whether the access method is ready for card assignment. This is true when the access method is in card mode, has not yet been issued, and the system supports credential assignment.
+         */
         public bool|null $is_ready_for_assignment,
+        /**
+         * Indicates whether the access method is ready to be encoded. This is true when the credential has been created and the card has not yet been issued.
+         */
         public bool|null $is_ready_for_encoding,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was encoded onto a card.
+         */
         public string|null $issued_at,
+        /**
+         * Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
+         */
         public string|null $latest_desired_state_synced_with_provider_at,
+        /**
+         * Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+         */
         public string|null $mode,
+        /**
+         * ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $parent_acs_credential_id,
+        /**
+         * Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
+         */
         public array $pending_mutations,
+        /**
+         * Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $starts_at,
+        /**
+         * ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+         */
         public string|null $user_identity_id,
+        /**
+         * Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public ActionAttemptVisionlineMetadata|null $visionline_metadata,
+        /**
+         * Warnings related to scanning the credential, such as mismatches between the credential data currently encoded on the card and the corresponding data stored on Seam and the access system.
+         */
         public array $warnings,
+        /**
+         * Indicates whether the device confirmed that the lock action occurred.
+         */
         public bool|null $was_confirmed_by_device,
+        /**
+         * ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * New access time configuration.
+ */
 class ActionAttemptTo
 {
     public static function from_json(mixed $json): ActionAttemptTo|null
@@ -409,11 +718,20 @@ class ActionAttemptTo
     }
 
     public function __construct(
+        /**
+         * New end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * New start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+ */
 class ActionAttemptVisionlineMetadata
 {
     public static function from_json(
@@ -439,21 +757,60 @@ class ActionAttemptVisionlineMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is cancelled.
+         */
         public bool|null $cancelled,
+        /**
+         * Format of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $card_format,
+        /**
+         * Holder of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $card_holder,
+        /**
+         * Card ID for the Visionline card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public string|null $card_id,
+        /**
+         * IDs of the common [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public array|null $common_acs_entrance_ids,
+        /**
+         * Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is discarded.
+         */
         public bool|null $discarded,
+        /**
+         * Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is expired.
+         */
         public bool|null $expired,
+        /**
+         * IDs of the guest [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public array|null $guest_acs_entrance_ids,
+        /**
+         * Number of issued cards associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+         */
         public float|null $number_of_issued_cards,
+        /**
+         * Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is overridden.
+         */
         public bool|null $overridden,
+        /**
+         * Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is overwritten.
+         */
         public bool|null $overwritten,
+        /**
+         * Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is pending auto-update.
+         */
         public bool|null $pending_auto_update,
     ) {}
 }
 
+/**
+ * Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+ */
 class ActionAttemptWarnings
 {
     public static function from_json(mixed $json): ActionAttemptWarnings|null
@@ -469,8 +826,17 @@ class ActionAttemptWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/Batch.php
+++ b/src/Resources/Batch.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * A batch of workspace resources.
+ */
 class Batch
 {
     public static function from_json(mixed $json): Batch|null
@@ -38,29 +41,178 @@ class Batch
     }
 
     public function __construct(
+        /**
+         * Represents a smart lock [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+         *
+         * An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly. Using the Seam Access Code API, you can easily generate access codes on the hundreds of door lock models with which we integrate.
+         *
+         * Seam supports programming two types of access codes: [ongoing](https://docs.seam.co/low-level-apis/smart-locks/access-codes#ongoing-access-codes) and [time-bound](https://docs.seam.co/low-level-apis/smart-locks/access-codes#time-bound-access-codes). To differentiate between the two, refer to the `type` property of the access code. Ongoing codes display as `ongoing`, whereas time-bound codes are labeled `time_bound`. An ongoing access code is active, until it has been removed from the device. To specify an ongoing access code, leave both `starts_at` and `ends_at` empty. A time-bound access code will be programmed at the `starts_at` time and removed at the `ends_at` time.
+         *
+         * In addition, for certain devices, Seam also supports [offline access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes#offline-access-codes). Offline access (PIN) codes are designed for door locks that might not always maintain an internet connection. For this type of access code, the device manufacturer uses encryption keys (tokens) to create server-based registries of algorithmically-generated offline PIN codes. Because the tokens remain synchronized with the managed devices, the locks do not require an active internet connection—and you do not need to be near the locks—to create an offline access code. Then, owners or managers can share these offline codes with users through a variety of mechanisms, such as messaging applications. That is, lock users do not need to install a smartphone application to receive an offline access code.
+         *
+         * For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
+         */
         public mixed $access_codes,
+        /**
+         * Represents an Access Grant. Access Grants enable you to grant a user identity access to spaces, entrances, and devices through one or more access methods, such as mobile keys, plastic cards, and PIN codes. You can create an Access Grant for an existing user identity, or you can create a new user identity *while* creating the new Access Grant.
+         */
         public mixed $access_grants,
+        /**
+         * Represents an access method for an Access Grant. Access methods describe the modes of access, such as PIN codes, plastic cards, and mobile keys. For a mobile key, the access method also stores the URL for the associated Instant Key.
+         */
         public mixed $access_methods,
+        /**
+         * Group that defines the entrances to which a set of users has access and, in some cases, the access schedule for these entrances and users.
+         *
+         * Some access control systems use [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups), which are sets of users, combined with sets of permissions. These permissions include both the set of areas or assets that the users can access and the schedule during which the users can access these areas or assets. Instead of assigning access rights individually to each access control system user, which can be time-consuming and error-prone, administrators can assign users to an access group, thereby ensuring that the users inherit all the permissions associated with the access group. Using access groups streamlines the process of managing large numbers of access control system users, especially in bigger organizations or complexes.
+         *
+         * To learn whether your access control system supports access groups, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+         */
         public mixed $acs_access_groups,
+        /**
+         * Means by which an [access control system user](https://docs.seam.co/low-level-apis/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         *
+         * An access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.
+         *
+         * For each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.
+         *
+         * For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach. Use the lower-level ACS credential API directly only when you specifically need to manage individual credentials.
+         */
         public mixed $acs_credentials,
+        /**
+         * Represents a hardware device that encodes [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) data onto physical cards within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         *
+         * Some access control systems require credentials to be encoded onto plastic key cards using a card encoder. This process involves the following two key steps:
+         *
+         * 1. Credential creation
+         *    Configure the access parameters for the credential.
+         * 2. Card encoding
+         *    Write the credential data onto the card using a compatible card encoder.
+         *
+         * Separately, the Seam API also supports card scanning, which enables you to scan and read the encoded data on a card. You can use this action to confirm consistency with access control system records or diagnose discrepancies if needed.
+         *
+         * See [Working with Card Encoders and Scanners](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+         *
+         * To verify if your access control system requires a card encoder, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+         */
         public mixed $acs_encoders,
+        /**
+         * Represents an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         *
+         * In an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the `acs_entrance` resources in your workspace or get these details for a specific `acs_entrance`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.
+         */
         public mixed $acs_entrances,
+        /**
+         * Represents an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+         *
+         * Within an `acs_system`, create [`acs_user`s](https://docs.seam.co/api/acs/users/object) and [`acs_credential`s](https://docs.seam.co/api/acs/credentials/object) to grant access to the `acs_user`s.
+         *
+         * For details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/api/acs).
+         */
         public mixed $acs_systems,
+        /**
+         * Represents a [user](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access system](https://docs.seam.co/low-level-apis/access-systems).
+         *
+         * An access system user typically refers to an individual who requires access, like an employee or resident. Each user can possess multiple credentials that serve as their keys or identifiers for access. The type of credential can vary widely. For example, in the Salto system, a user can have a PIN code, a mobile app account, and a fob. In other platforms, it is not uncommon for a user to have more than one of the same credential type, such as multiple key cards. Additionally, these credentials can have a schedule or validity period.
+         *
+         * For details about how to configure users in your access system, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+         */
         public mixed $acs_users,
+        /**
+         * Represents an action attempt that enables you to keep track of the progress of your action that affects a physical device or system.actions against a device. Action attempts are useful because the physical world is intrinsically asynchronous.
+         *
+         * When you request for a device to perform an action, the Seam API immediately returns an action attempt object. In the background, the Seam API performs the action.
+         *
+         * See also [Action Attempts](https://docs.seam.co/core-concepts/action-attempts).
+         */
         public mixed $action_attempts,
+        /**
+         * Represents a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens). If you want to restrict your users' access to their own devices, use client sessions.
+         *
+         * You create each client session with a custom `user_identifier_key`. Normally, the `user_identifier_key` is a user ID that your application provides.
+         *
+         * When calling the Seam API from your backend using an API key, you can pass the `user_identifier_key` as a parameter to limit results to the associated client session. For example, `/devices/list?user_identifier_key=123` only returns devices associated with the client session created with the `user_identifier_key` `123`.
+         *
+         * A client session has a token that you can use with the Seam JavaScript SDK to make requests from the client (browser) directly to the Seam API. The token restricts the user's access to only the devices that they own.
+         *
+         * See also [Get Started with React](https://docs.seam.co/ui-components/overview/getting-started-with-seam-components/get-started-with-react-components-and-client-session-tokens).
+         */
         public mixed $client_sessions,
+        /**
+         * Represents a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+         *
+         * Connect Webviews are fully-embedded client-side components that you add to your app. Your users interact with your embedded Connect Webviews to link their IoT device or system accounts to Seam. That is, Connect Webviews walk your users through the process of logging in to their device or system accounts. Seam handles all the authentication steps, and—once your user has completed the authorization through your app—you can access and control their devices or systems using the Seam API.
+         *
+         * Connect Webviews perform credential validation, multifactor authentication (when applicable), and error handling for each brand that Seam supports. Further, Connect Webviews work across all modern browsers and platforms, including Chrome, Safari, and Firefox.
+         *
+         * To enable a user to connect their device or system account to Seam through your app, first create a `connect_webview`. Once created, this `connect_webview` includes a URL that you can use to open an [iframe](https://www.w3schools.com/html/html_iframe.asp) or new window containing the Connect Webview for your user.
+         *
+         * When you create a Connect Webview, specify the desired provider category key in the `provider_category` parameter. Alternately, to specify a list of providers explicitly, use the `accepted_providers` parameter with a list of device provider keys.
+         *
+         * To list all providers within a category, use `/devices/list_device_providers` with the desired `provider_category` filter. To list all provider keys, use `/devices/list_device_providers` with no filters.
+         */
         public mixed $connect_webviews,
+        /**
+         * Represents a [connected account](https://docs.seam.co/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.
+         */
         public mixed $connected_accounts,
+        /**
+         * Represents a [device](https://docs.seam.co/core-concepts/devices) that has been connected to Seam.
+         */
         public mixed $devices,
+        /**
+         * Represents an event. Events let you know when something interesting happens in your workspace. For example, when a lock is unlocked, Seam creates a `lock.unlocked` event. When a device's battery level is low, Seam creates a `device.battery_low` event.
+         *
+         * As with other API resources, you can retrieve an individual event or a list of events. Seam also provides a separate webhook system for sending the event objects directly to an endpoint on your sever. Manage webhooks through [Seam Console](https://console.seam.co). You can also use the webhooks sandbox in Seam Console to see the different payloads for each event and test them against your own endpoints.
+         */
         public mixed $events,
+        /**
+         * Represents a Seam Instant Key. For issuing Bluetooth mobile keys, Instant Keys are the fastest way to share access. With a single API call, you can create a mobile key and send it through text or email or embed it in your own app.
+         *
+         * There’s no app to install, nor account to create. Your user just taps a link and gets a lightweight, native-feeling experience using iOS App Clip or Instant Apps on Android. Further, Instant Keys work offline, so even in areas with poor cellular or Wi-Fi, like elevator banks or concrete-walled hallways, the Instant Keys still work.
+         */
         public mixed $instant_keys,
+        /**
+         * Represents a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+         */
         public mixed $noise_thresholds,
+        /**
+         * Represents a space that is a logical grouping of devices and entrances. You can assign access to an entire space, thereby making granting access more efficient.
+         */
         public mixed $spaces,
+        /**
+         * Represents a thermostat daily program, consisting of a set of periods, each of which has a starting time and the key that identifies the climate preset to apply at the starting time.
+         */
         public mixed $thermostat_daily_programs,
+        /**
+         * Represents a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) that activates a configured [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) on a [thermostat](https://docs.seam.co/capability-guides/thermostats) at a specified starting time and deactivates the climate preset at a specified ending time.
+         */
         public mixed $thermostat_schedules,
+        /**
+         * Represents an [unmanaged smart lock access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+         *
+         * An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly.
+         *
+         * When you create an access code on a device in Seam, it is created as a managed access code. Access codes that exist on a device that were not created through Seam are considered unmanaged codes. We strictly limit the operations that can be performed on unmanaged codes.
+         *
+         * Prior to using Seam to manage your devices, you may have used another lock management system to manage the access codes on your devices. Where possible, we help you keep any existing access codes on devices and transition those codes to ones managed by your Seam workspace.
+         *
+         * Not all providers support unmanaged access codes. The following providers do not support unmanaged access codes:
+         *
+         * - [Kwikset](https://docs.seam.co/device-and-system-integration-guides/kwikset-locks)
+         */
         public mixed $unmanaged_access_codes,
+        /**
+         * Represents an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+         */
         public mixed $unmanaged_devices,
+        /**
+         * Represents a [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with an application user account.
+         */
         public mixed $user_identities,
+        /**
+         * Represents a Seam [workspace](https://docs.seam.co/core-concepts/workspaces). A workspace is a top-level entity that encompasses all other resources below it, such as devices, connected accounts, and Connect Webviews. Seam provides two types of workspaces. A [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is a special type of workspace designed for testing code. Sandbox workspaces offer test device accounts and virtual devices that you can connect and control. This ability to work with virtual devices is quite handy because it removes the need to own physical devices from multiple brands. To connect real devices and systems to Seam, use a [production workspace](https://docs.seam.co/core-concepts/workspaces#production-workspaces).
+         */
         public mixed $workspaces,
     ) {}
 }

--- a/src/Resources/ClientSession.php
+++ b/src/Resources/ClientSession.php
@@ -2,6 +2,17 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens). If you want to restrict your users' access to their own devices, use client sessions.
+ *
+ * You create each client session with a custom `user_identifier_key`. Normally, the `user_identifier_key` is a user ID that your application provides.
+ *
+ * When calling the Seam API from your backend using an API key, you can pass the `user_identifier_key` as a parameter to limit results to the associated client session. For example, `/devices/list?user_identifier_key=123` only returns devices associated with the client session created with the `user_identifier_key` `123`.
+ *
+ * A client session has a token that you can use with the Seam JavaScript SDK to make requests from the client (browser) directly to the Seam API. The token restricts the user's access to only the devices that they own.
+ *
+ * See also [Get Started with React](https://docs.seam.co/ui-components/overview/getting-started-with-seam-components/get-started-with-react-components-and-client-session-tokens).
+ */
 class ClientSession
 {
     public static function from_json(mixed $json): ClientSession|null
@@ -26,17 +37,55 @@ class ClientSession
     }
 
     public function __construct(
+        /**
+         * ID of the client session.
+         */
         public string|null $client_session_id,
+        /**
+         * IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+         */
         public array|null $connect_webview_ids,
+        /**
+         * IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+         */
         public array|null $connected_account_ids,
+        /**
+         * Date and time at which the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) was created.
+         */
         public string|null $created_at,
+        /**
+         * Customer key associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+         */
         public string|null $customer_key,
+        /**
+         * Number of devices associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+         */
         public float|null $device_count,
+        /**
+         * Date and time at which the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) expires.
+         */
         public string|null $expires_at,
+        /**
+         * Client session token associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+         */
         public string|null $token,
+        /**
+         * Your user ID for the user associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+         */
         public string|null $user_identifier_key,
+        /**
+         * ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.
+         */
         public string|null $user_identity_id,
+        /**
+         * IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.
+         *
+         * @deprecated Use `user_identity_id` instead.
+         */
         public array|null $user_identity_ids,
+        /**
+         * ID of the workspace associated with the client session.
+         */
         public string|null $workspace_id,
     ) {}
 }

--- a/src/Resources/ConnectWebview.php
+++ b/src/Resources/ConnectWebview.php
@@ -2,6 +2,19 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+ *
+ * Connect Webviews are fully-embedded client-side components that you add to your app. Your users interact with your embedded Connect Webviews to link their IoT device or system accounts to Seam. That is, Connect Webviews walk your users through the process of logging in to their device or system accounts. Seam handles all the authentication steps, and—once your user has completed the authorization through your app—you can access and control their devices or systems using the Seam API.
+ *
+ * Connect Webviews perform credential validation, multifactor authentication (when applicable), and error handling for each brand that Seam supports. Further, Connect Webviews work across all modern browsers and platforms, including Chrome, Safari, and Firefox.
+ *
+ * To enable a user to connect their device or system account to Seam through your app, first create a `connect_webview`. Once created, this `connect_webview` includes a URL that you can use to open an [iframe](https://www.w3schools.com/html/html_iframe.asp) or new window containing the Connect Webview for your user.
+ *
+ * When you create a Connect Webview, specify the desired provider category key in the `provider_category` parameter. Alternately, to specify a list of providers explicitly, use the `accepted_providers` parameter with a list of device provider keys.
+ *
+ * To list all providers within a category, use `/devices/list_device_providers` with the desired `provider_category` filter. To list all provider keys, use `/devices/list_device_providers` with no filters.
+ */
 class ConnectWebview
 {
     public static function from_json(mixed $json): ConnectWebview|null
@@ -35,24 +48,81 @@ class ConnectWebview
     }
 
     public function __construct(
+        /**
+         * High-level device capabilities that the Connect Webview can accept. When creating a Connect Webview, you can specify the types of devices that it can connect to Seam. If you do not set custom `accepted_capabilities`, Seam uses a default set of `accepted_capabilities` for each provider. For example, if you create a Connect Webview that accepts SmartThing devices, without specifying `accepted_capabilities`, Seam accepts only SmartThings locks. To connect SmartThings thermostats and locks to Seam, create a Connect Webview and include both `thermostat` and `lock` in the `accepted_capabilities`.
+         */
         public array|null $accepted_capabilities,
+        /**
+         * List of accepted [provider keys](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
+         */
         public array|null $accepted_providers,
+        /**
+         * Indicates whether any provider is allowed.
+         */
         public bool|null $any_provider_allowed,
+        /**
+         * Date and time at which the user authorized (through the Connect Webview) the management of their devices.
+         */
         public string|null $authorized_at,
+        /**
+         * Indicates whether Seam should [import all new devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for use and management by the Seam API.
+         */
         public bool|null $automatically_manage_new_devices,
+        /**
+         * ID of the Connect Webview.
+         */
         public string|null $connect_webview_id,
+        /**
+         * ID of the connected account associated with the Connect Webview.
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the Connect Webview was created.
+         */
         public string|null $created_at,
+        /**
+         * Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.
+         */
         public mixed $custom_metadata,
+        /**
+         * URL to which the Connect Webview should redirect when an unexpected error occurs.
+         */
         public string|null $custom_redirect_failure_url,
+        /**
+         * URL to which the Connect Webview should redirect when the user successfully pairs a device or system. If you do not set the `custom_redirect_failure_url`, the Connect Webview redirects to the `custom_redirect_url` when an unexpected error occurs.
+         */
         public string|null $custom_redirect_url,
+        /**
+         * The customer key associated with this webview, if any.
+         */
         public string|null $customer_key,
+        /**
+         * Device selection mode of the Connect Webview. Supported values: `none`, `single`, `multiple`.
+         */
         public string|null $device_selection_mode,
+        /**
+         * Indicates whether the user logged in successfully using the Connect Webview.
+         */
         public bool|null $login_successful,
+        /**
+         * Selected provider of the Connect Webview, one of the [provider keys](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
+         */
         public string|null $selected_provider,
+        /**
+         * Status of the Connect Webview. `authorized` indicates that the user has successfully logged into their device or system account, thereby completing the Connect Webview.
+         */
         public string|null $status,
+        /**
+         * URL for the Connect Webview. You use the URL to display the Connect Webview flow to your user.
+         */
         public string|null $url,
+        /**
+         * Indicates whether Seam should [finish syncing all devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#wait_for_device_creation) in a newly-connected account before completing the associated Connect Webview.
+         */
         public bool|null $wait_for_device_creation,
+        /**
+         * ID of the workspace that contains the Connect Webview.
+         */
         public string|null $workspace_id,
     ) {}
 }

--- a/src/Resources/ConnectedAccount.php
+++ b/src/Resources/ConnectedAccount.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a [connected account](https://docs.seam.co/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.
+ */
 class ConnectedAccount
 {
     public static function from_json(mixed $json): ConnectedAccount|null
@@ -43,27 +46,86 @@ class ConnectedAccount
     }
 
     public function __construct(
+        /**
+         * List of capabilities that were accepted during the account connection process.
+         */
         public array|null $accepted_capabilities,
+        /**
+         * Type of connected account.
+         */
         public string|null $account_type,
+        /**
+         * Display name for the connected account type.
+         */
         public string|null $account_type_display_name,
+        /**
+         * Indicates whether Seam should [import all new devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for management by the Seam API.
+         */
         public bool|null $automatically_manage_new_devices,
+        /**
+         * ID of the connected account.
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the connected account was created.
+         */
         public string|null $created_at,
+        /**
+         * Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.
+         */
         public mixed $custom_metadata,
+        /**
+         * Your unique key for the customer associated with this connected account.
+         */
         public string|null $customer_key,
+        /**
+         * Default reservation check-in time for this connected account, as `HH:mm` (24-hour). Sourced from the connector configuration — set during the connect_webview for providers like Lodgify whose API does not expose check-in times.
+         */
         public string|null $default_checkin_time,
+        /**
+         * Default reservation check-out time for this connected account, as `HH:mm` (24-hour). Sourced from the connector configuration.
+         */
         public string|null $default_checkout_time,
+        /**
+         * Display name for the connected account.
+         */
         public string|null $display_name,
+        /**
+         * Errors associated with the connected account.
+         */
         public array $errors,
+        /**
+         * For iCal connected accounts, the platform that produced the feed (for example, `airbnb`, `vrbo`, or `booking`), or `unknown` when it could not be determined. Intended for rendering the source platform's logo.
+         */
         public string|null $ical_feed_origin,
+        /**
+         * For iCal connected accounts, the feed URL for the connection. Sourced from the connector configuration.
+         */
         public string|null $ical_url,
+        /**
+         * Logo URL for the connected account provider.
+         */
         public string|null $image_url,
+        /**
+         * IANA time zone (e.g. America/Los_Angeles) for this connected account. Sourced from the connector configuration.
+         */
         public string|null $time_zone,
+        /**
+         * User identifier associated with the connected account.
+         *
+         * @deprecated Use `display_name` instead.
+         */
         public ConnectedAccountUserIdentifier|null $user_identifier,
+        /**
+         * Warnings associated with the connected account.
+         */
         public array $warnings,
     ) {}
 }
 
+/**
+ * Errors associated with the connected account.
+ */
 class ConnectedAccountErrors
 {
     public static function from_json(mixed $json): ConnectedAccountErrors|null
@@ -87,15 +149,36 @@ class ConnectedAccountErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+         */
         public bool|null $is_bridge_error,
+        /**
+         * Indicates whether the error is related specifically to the connected account.
+         */
         public bool|null $is_connected_account_error,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Salto KS metadata associated with the connected account that has an error.
+         */
         public ConnectedAccountSaltoKsMetadata|null $salto_ks_metadata,
     ) {}
 }
 
+/**
+ * Salto KS metadata associated with the connected account that has an error.
+ */
 class ConnectedAccountSaltoKsMetadata
 {
     public static function from_json(
@@ -112,9 +195,17 @@ class ConnectedAccountSaltoKsMetadata
         );
     }
 
-    public function __construct(public array $sites) {}
+    public function __construct(
+        /**
+         * Salto sites associated with the connected account that has an error.
+         */
+        public array $sites,
+    ) {}
 }
 
+/**
+ * Salto sites associated with the connected account that has an error.
+ */
 class ConnectedAccountSites
 {
     public static function from_json(mixed $json): ConnectedAccountSites|null
@@ -133,13 +224,28 @@ class ConnectedAccountSites
     }
 
     public function __construct(
+        /**
+         * ID of a Salto site associated with the connected account that has an error.
+         */
         public string|null $site_id,
+        /**
+         * Name of a Salto site associated with the connected account that has an error.
+         */
         public string|null $site_name,
+        /**
+         * Subscription limit of site users for a Salto site associated with the connected account that has an error.
+         */
         public int|null $site_user_subscription_limit,
+        /**
+         * Count of subscribed site users for a Salto site associated with the connected account that has an error.
+         */
         public int|null $subscribed_site_user_count,
     ) {}
 }
 
+/**
+ * User identifier associated with the connected account.
+ */
 class ConnectedAccountUserIdentifier
 {
     public static function from_json(
@@ -158,14 +264,32 @@ class ConnectedAccountUserIdentifier
     }
 
     public function __construct(
+        /**
+         * API URL for the user identifier associated with the connected account.
+         */
         public string|null $api_url,
+        /**
+         * Email address of the user identifier associated with the connected account.
+         */
         public string|null $email,
+        /**
+         * Indicates whether the user identifier associated with the connected account is exclusive.
+         */
         public bool|null $exclusive,
+        /**
+         * Phone number of the user identifier associated with the connected account.
+         */
         public string|null $phone,
+        /**
+         * Username of the user identifier associated with the connected account.
+         */
         public string|null $username,
     ) {}
 }
 
+/**
+ * Warnings associated with the connected account.
+ */
 class ConnectedAccountWarnings
 {
     public static function from_json(mixed $json): ConnectedAccountWarnings|null
@@ -186,9 +310,21 @@ class ConnectedAccountWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Salto KS metadata associated with the connected account that has a warning.
+         */
         public ConnectedAccountSaltoKsMetadata|null $salto_ks_metadata,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/CustomerPortal.php
+++ b/src/Resources/CustomerPortal.php
@@ -2,6 +2,13 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a Customer Portal. Customer Portal is a hosted, customizable interface for managing device access. It enables you to embed secure, pre-authenticated access flows into your product—either by sharing a link with users or embedding a view in an iframe.
+ *
+ * With Customer Portal, you no longer need to build out frontend experiences for physical access, thermostats, and sensors. Instead, you can ship enterprise-grade access control experiences in a fraction of the time, while maintaining your product's branding and user experience.
+ *
+ * Seam hosts these flows, handling everything from account connection and device mapping to full-featured device control.
+ */
 class CustomerPortal
 {
     public static function from_json(mixed $json): CustomerPortal|null
@@ -19,10 +26,25 @@ class CustomerPortal
     }
 
     public function __construct(
+        /**
+         * Date and time at which the customer portal link was created.
+         */
         public string|null $created_at,
+        /**
+         * Customer key for the customer portal.
+         */
         public string|null $customer_key,
+        /**
+         * Date and time at which the customer portal link expires.
+         */
         public string|null $expires_at,
+        /**
+         * URL for the customer portal.
+         */
         public string|null $url,
+        /**
+         * ID of the workspace associated with the customer portal.
+         */
         public string|null $workspace_id,
     ) {}
 }

--- a/src/Resources/Device.php
+++ b/src/Resources/Device.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a [device](https://docs.seam.co/core-concepts/devices) that has been connected to Seam.
+ */
 class Device
 {
     public static function from_json(mixed $json): Device|null
@@ -77,46 +80,160 @@ class Device
     }
 
     public function __construct(
+        /**
+         * Indicates whether the lock supports configuring automatic locking.
+         */
         public bool|null $can_configure_auto_lock,
+        /**
+         * Indicates whether the thermostat supports cooling.
+         */
         public bool|null $can_hvac_cool,
+        /**
+         * Indicates whether the thermostat supports heating.
+         */
         public bool|null $can_hvac_heat,
+        /**
+         * Indicates whether the thermostat supports simultaneous heating and cooling.
+         */
         public bool|null $can_hvac_heat_cool,
+        /**
+         * Indicates whether the device supports programming offline access codes.
+         */
         public bool|null $can_program_offline_access_codes,
+        /**
+         * Indicates whether the device supports programming online access codes.
+         */
         public bool|null $can_program_online_access_codes,
+        /**
+         * Indicates whether the thermostat supports different climate programs for each day of the week.
+         */
         public bool|null $can_program_thermostat_programs_as_different_each_day,
+        /**
+         * Indicates whether the thermostat supports a single climate program applied to every day.
+         */
         public bool|null $can_program_thermostat_programs_as_same_each_day,
+        /**
+         * Indicates whether the thermostat supports weekday/weekend climate programs.
+         */
         public bool|null $can_program_thermostat_programs_as_weekday_weekend,
+        /**
+         * Indicates whether the device supports remote locking.
+         */
         public bool|null $can_remotely_lock,
+        /**
+         * Indicates whether the device supports remote unlocking.
+         */
         public bool|null $can_remotely_unlock,
+        /**
+         * Indicates whether the thermostat supports running climate programs.
+         */
         public bool|null $can_run_thermostat_programs,
+        /**
+         * Indicates whether the device supports simulating connection in a sandbox.
+         */
         public bool|null $can_simulate_connection,
+        /**
+         * Indicates whether the device supports simulating disconnection in a sandbox.
+         */
         public bool|null $can_simulate_disconnection,
+        /**
+         * Indicates whether the hub supports simulating connection in a sandbox.
+         */
         public bool|null $can_simulate_hub_connection,
+        /**
+         * Indicates whether the hub supports simulating disconnection in a sandbox.
+         */
         public bool|null $can_simulate_hub_disconnection,
+        /**
+         * Indicates whether the device supports simulating a paid subscription in a sandbox.
+         */
         public bool|null $can_simulate_paid_subscription,
+        /**
+         * Indicates whether the device supports simulating removal in a sandbox.
+         */
         public bool|null $can_simulate_removal,
+        /**
+         * Indicates whether the thermostat can be turned off.
+         */
         public bool|null $can_turn_off_hvac,
+        /**
+         * Indicates whether the lock supports unlocking with an access code.
+         */
         public bool|null $can_unlock_with_code,
+        /**
+         * Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
+         */
         public array|null $capabilities_supported,
+        /**
+         * Unique identifier for the account associated with the device.
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the device object was created.
+         */
         public string|null $created_at,
+        /**
+         * Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.
+         */
         public mixed $custom_metadata,
+        /**
+         * ID of the device.
+         */
         public string|null $device_id,
+        /**
+         * Manufacturer of the device. Represents the hardware brand, which may differ from the provider.
+         */
         public DeviceDeviceManufacturer|null $device_manufacturer,
+        /**
+         * Provider of the device. Represents the third-party service through which the device is controlled.
+         */
         public DeviceDeviceProvider|null $device_provider,
+        /**
+         * Type of the device.
+         */
         public string|null $device_type,
+        /**
+         * Display name of the device, defaults to nickname (if it is set) or `properties.appearance.name`, otherwise. Enables administrators and users to identify the device easily, especially when there are numerous devices.
+         */
         public string|null $display_name,
+        /**
+         * Array of errors associated with the device. Each error object within the array contains two fields: `error_code` and `message`. `error_code` is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+         */
         public array $errors,
+        /**
+         * Indicates whether Seam manages the device. See also [Managed and Unmanaged Devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+         */
         public bool|null $is_managed,
+        /**
+         * Location information for the device.
+         */
         public DeviceLocation|null $location,
+        /**
+         * Optional nickname to describe the device, settable through Seam.
+         */
         public string|null $nickname,
+        /**
+         * Properties of the device.
+         */
         public DeviceProperties|null $properties,
+        /**
+         * IDs of the spaces the device is in.
+         */
         public array|null $space_ids,
+        /**
+         * Array of warnings associated with the device. Each warning object within the array contains two fields: `warning_code` and `message`. `warning_code` is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+         */
         public array $warnings,
+        /**
+         * Unique identifier for the Seam workspace associated with the device.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Latest accelerometer Z-axis reading for a Minut device.
+ */
 class DeviceAccelerometerZ
 {
     public static function from_json(mixed $json): DeviceAccelerometerZ|null
@@ -128,11 +245,20 @@ class DeviceAccelerometerZ
     }
 
     public function __construct(
+        /**
+         * Time of latest accelerometer Z-axis reading for a Minut device.
+         */
         public string|null $time,
+        /**
+         * Value of latest accelerometer Z-axis reading for a Minut device.
+         */
         public float|null $value,
     ) {}
 }
 
+/**
+ * Accessory keypad properties and state.
+ */
 class DeviceAccessoryKeypad
 {
     public static function from_json(mixed $json): DeviceAccessoryKeypad|null
@@ -149,11 +275,20 @@ class DeviceAccessoryKeypad
     }
 
     public function __construct(
+        /**
+         * Keypad battery properties.
+         */
         public DeviceBattery|null $battery,
+        /**
+         * Indicates if an accessory keypad is connected to the device.
+         */
         public bool|null $is_connected,
     ) {}
 }
 
+/**
+ * Active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+ */
 class DeviceActiveThermostatSchedule
 {
     public static function from_json(
@@ -182,20 +317,56 @@ class DeviceActiveThermostatSchedule
     }
 
     public function __construct(
+        /**
+         * Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         */
         public string|null $climate_preset_key,
+        /**
+         * Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.
+         */
         public string|null $created_at,
+        /**
+         * ID of the desired [thermostat](https://docs.seam.co/capability-guides/thermostats) device.
+         */
         public string|null $device_id,
+        /**
+         * Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $ends_at,
+        /**
+         * Errors associated with the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         */
         public array $errors,
+        /**
+         * Indicates whether a person at the thermostat can change the thermostat's settings after the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.
+         */
         public bool|null $is_override_allowed,
+        /**
+         * Number of minutes for which a person at the thermostat can change the thermostat's settings after the activation of the scheduled [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+         */
         public int|null $max_override_period_minutes,
+        /**
+         * User-friendly name to identify the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         */
         public string|null $name,
+        /**
+         * Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $starts_at,
+        /**
+         * ID of the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         */
         public string|null $thermostat_schedule_id,
+        /**
+         * ID of the workspace that contains the thermostat schedule.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Metadata for an Akiles device.
+ */
 class DeviceAkilesMetadata
 {
     public static function from_json(mixed $json): DeviceAkilesMetadata|null
@@ -212,13 +383,28 @@ class DeviceAkilesMetadata
     }
 
     public function __construct(
+        /**
+         * Group ID to which to add users for an Akiles device.
+         */
         public string|null $_member_group_id,
+        /**
+         * Gadget ID for an Akiles device.
+         */
         public string|null $gadget_id,
+        /**
+         * Gadget name for an Akiles device.
+         */
         public string|null $gadget_name,
+        /**
+         * Product name for an Akiles device.
+         */
         public string|null $product_name,
     ) {}
 }
 
+/**
+ * Appearance-related properties, as reported by the device.
+ */
 class DeviceAppearance
 {
     public static function from_json(mixed $json): DeviceAppearance|null
@@ -229,9 +415,17 @@ class DeviceAppearance
         return new self(name: $json->name ?? null);
     }
 
-    public function __construct(public string|null $name) {}
+    public function __construct(
+        /**
+         * Name of the device as seen from the provider API and application, not settable through Seam.
+         */
+        public string|null $name,
+    ) {}
 }
 
+/**
+ * Metadata for an Aqara device.
+ */
 class DeviceAqaraMetadata
 {
     public static function from_json(mixed $json): DeviceAqaraMetadata|null
@@ -252,17 +446,44 @@ class DeviceAqaraMetadata
     }
 
     public function __construct(
+        /**
+         * Device name for an Aqara device.
+         */
         public string|null $device_name,
+        /**
+         * Device ID (did) for an Aqara device.
+         */
         public string|null $did,
+        /**
+         * Firmware version for an Aqara device.
+         */
         public string|null $firmware_version,
+        /**
+         * Model identifier for an Aqara device.
+         */
         public string|null $model,
+        /**
+         * Model type for an Aqara device.
+         */
         public float|null $model_type,
+        /**
+         * Parent gateway device ID for an Aqara device.
+         */
         public string|null $parent_did,
+        /**
+         * Position (room) ID for an Aqara device.
+         */
         public string|null $position_id,
+        /**
+         * Time zone reported for an Aqara device (e.g. GMT-07:00).
+         */
         public string|null $time_zone,
     ) {}
 }
 
+/**
+ * ASSA ABLOY Credential Service metadata for the phone.
+ */
 class DeviceAssaAbloyCredentialServiceMetadata
 {
     public static function from_json(
@@ -281,11 +502,20 @@ class DeviceAssaAbloyCredentialServiceMetadata
     }
 
     public function __construct(
+        /**
+         * Endpoints associated with the phone.
+         */
         public array $endpoints,
+        /**
+         * Indicates whether the credential service has active endpoints associated with the phone.
+         */
         public bool|null $has_active_endpoint,
     ) {}
 }
 
+/**
+ * Metadata for an ASSA ABLOY Vostio system.
+ */
 class DeviceAssaAbloyVostioMetadata
 {
     public static function from_json(
@@ -297,9 +527,17 @@ class DeviceAssaAbloyVostioMetadata
         return new self(encoder_name: $json->encoder_name ?? null);
     }
 
-    public function __construct(public string|null $encoder_name) {}
+    public function __construct(
+        /**
+         * Encoder name for an ASSA ABLOY Vostio system.
+         */
+        public string|null $encoder_name,
+    ) {}
 }
 
+/**
+ * Metadata for an August device.
+ */
 class DeviceAugustMetadata
 {
     public static function from_json(mixed $json): DeviceAugustMetadata|null
@@ -319,16 +557,40 @@ class DeviceAugustMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether an August device has a keypad.
+         */
         public bool|null $has_keypad,
+        /**
+         * House ID for an August device.
+         */
         public string|null $house_id,
+        /**
+         * House name for an August device.
+         */
         public string|null $house_name,
+        /**
+         * Keypad battery level for an August device.
+         */
         public string|null $keypad_battery_level,
+        /**
+         * Lock ID for an August device.
+         */
         public string|null $lock_id,
+        /**
+         * Lock name for an August device.
+         */
         public string|null $lock_name,
+        /**
+         * Model for an August device.
+         */
         public string|null $model,
     ) {}
 }
 
+/**
+ * Available [climate presets](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for the thermostat.
+ */
 class DeviceAvailableClimatePresets
 {
     public static function from_json(
@@ -362,24 +624,74 @@ class DeviceAvailableClimatePresets
     }
 
     public function __construct(
+        /**
+         * Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.
+         */
         public bool|null $can_delete,
+        /**
+         * Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.
+         */
         public bool|null $can_edit,
+        /**
+         * Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.
+         */
         public bool|null $can_use_with_thermostat_daily_programs,
+        /**
+         * Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+         */
         public string|null $climate_preset_key,
+        /**
+         * The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+         */
         public string|null $climate_preset_mode,
+        /**
+         * Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $cooling_set_point_celsius,
+        /**
+         * Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $cooling_set_point_fahrenheit,
+        /**
+         * Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+         */
         public string|null $display_name,
+        /**
+         * Metadata specific to the Ecobee climate, if applicable.
+         */
         public DeviceEcobeeMetadata|null $ecobee_metadata,
+        /**
+         * Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+         */
         public string|null $fan_mode_setting,
+        /**
+         * Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $heating_set_point_celsius,
+        /**
+         * Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $heating_set_point_fahrenheit,
+        /**
+         * Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+         */
         public string|null $hvac_mode_setting,
+        /**
+         * Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+         *
+         * @deprecated Use 'thermostat_schedule.is_override_allowed'
+         */
         public bool|null $manual_override_allowed,
+        /**
+         * User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+         */
         public string|null $name,
     ) {}
 }
 
+/**
+ * Metadata for an Avigilon Alta system.
+ */
 class DeviceAvigilonAltaMetadata
 {
     public static function from_json(
@@ -400,16 +712,40 @@ class DeviceAvigilonAltaMetadata
     }
 
     public function __construct(
+        /**
+         * Entry name for an Avigilon Alta system.
+         */
         public string|null $entry_name,
+        /**
+         * Total count of entry relays for an Avigilon Alta system.
+         */
         public float|null $entry_relays_total_count,
+        /**
+         * Organization name for an Avigilon Alta system.
+         */
         public string|null $org_name,
+        /**
+         * Site ID for an Avigilon Alta system.
+         */
         public float|null $site_id,
+        /**
+         * Site name for an Avigilon Alta system.
+         */
         public string|null $site_name,
+        /**
+         * Zone ID for an Avigilon Alta system.
+         */
         public float|null $zone_id,
+        /**
+         * Zone name for an Avigilon Alta system.
+         */
         public string|null $zone_name,
     ) {}
 }
 
+/**
+ * Keypad battery properties.
+ */
 class DeviceBattery
 {
     public static function from_json(mixed $json): DeviceBattery|null
@@ -423,6 +759,9 @@ class DeviceBattery
     public function __construct(public float|null $level) {}
 }
 
+/**
+ * Metadata for a Brivo device.
+ */
 class DeviceBrivoMetadata
 {
     public static function from_json(mixed $json): DeviceBrivoMetadata|null
@@ -437,11 +776,20 @@ class DeviceBrivoMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether the Brivo access point has activation (remote unlock) enabled.
+         */
         public bool|null $activation_enabled,
+        /**
+         * Device name for a Brivo device.
+         */
         public string|null $device_name,
     ) {}
 }
 
+/**
+ * Constraints on access codes for the device. Seam represents each constraint as an object with a `constraint_type` property. Depending on the constraint type, there may also be additional properties. Note that some constraints are manufacturer- or device-specific.
+ */
 class DeviceCodeConstraints
 {
     public static function from_json(mixed $json): DeviceCodeConstraints|null
@@ -458,11 +806,20 @@ class DeviceCodeConstraints
 
     public function __construct(
         public string|null $constraint_type,
+        /**
+         * Maximum name length constraint for access codes.
+         */
         public float|null $max_length,
+        /**
+         * Minimum name length constraint for access codes.
+         */
         public float|null $min_length,
     ) {}
 }
 
+/**
+ * Metadata for a ControlByWeb device.
+ */
 class DeviceControlbywebMetadata
 {
     public static function from_json(
@@ -479,12 +836,24 @@ class DeviceControlbywebMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a ControlByWeb device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a ControlByWeb device.
+         */
         public string|null $device_name,
+        /**
+         * Relay name for a ControlByWeb device.
+         */
         public string|null $relay_name,
     ) {}
 }
 
+/**
+ * Current climate setting.
+ */
 class DeviceCurrentClimateSetting
 {
     public static function from_json(
@@ -518,20 +887,67 @@ class DeviceCurrentClimateSetting
     }
 
     public function __construct(
+        /**
+         * Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.
+         */
         public bool|null $can_delete,
+        /**
+         * Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.
+         */
         public bool|null $can_edit,
+        /**
+         * Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.
+         */
         public bool|null $can_use_with_thermostat_daily_programs,
+        /**
+         * Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+         */
         public string|null $climate_preset_key,
+        /**
+         * The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+         */
         public string|null $climate_preset_mode,
+        /**
+         * Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $cooling_set_point_celsius,
+        /**
+         * Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $cooling_set_point_fahrenheit,
+        /**
+         * Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+         */
         public string|null $display_name,
+        /**
+         * Metadata specific to the Ecobee climate, if applicable.
+         */
         public DeviceEcobeeMetadata|null $ecobee_metadata,
+        /**
+         * Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+         */
         public string|null $fan_mode_setting,
+        /**
+         * Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $heating_set_point_celsius,
+        /**
+         * Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $heating_set_point_fahrenheit,
+        /**
+         * Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+         */
         public string|null $hvac_mode_setting,
+        /**
+         * Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+         *
+         * @deprecated Use 'thermostat_schedule.is_override_allowed'
+         */
         public bool|null $manual_override_allowed,
+        /**
+         * User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+         */
         public string|null $name,
     ) {}
 }
@@ -569,24 +985,74 @@ class DeviceDefaultClimateSetting
     }
 
     public function __construct(
+        /**
+         * Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.
+         */
         public bool|null $can_delete,
+        /**
+         * Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.
+         */
         public bool|null $can_edit,
+        /**
+         * Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.
+         */
         public bool|null $can_use_with_thermostat_daily_programs,
+        /**
+         * Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+         */
         public string|null $climate_preset_key,
+        /**
+         * The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+         */
         public string|null $climate_preset_mode,
+        /**
+         * Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $cooling_set_point_celsius,
+        /**
+         * Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $cooling_set_point_fahrenheit,
+        /**
+         * Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+         */
         public string|null $display_name,
+        /**
+         * Metadata specific to the Ecobee climate, if applicable.
+         */
         public DeviceEcobeeMetadata|null $ecobee_metadata,
+        /**
+         * Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+         */
         public string|null $fan_mode_setting,
+        /**
+         * Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $heating_set_point_celsius,
+        /**
+         * Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $heating_set_point_fahrenheit,
+        /**
+         * Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+         */
         public string|null $hvac_mode_setting,
+        /**
+         * Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+         *
+         * @deprecated Use 'thermostat_schedule.is_override_allowed'
+         */
         public bool|null $manual_override_allowed,
+        /**
+         * User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+         */
         public string|null $name,
     ) {}
 }
 
+/**
+ * Manufacturer of the device. Represents the hardware brand, which may differ from the provider.
+ */
 class DeviceDeviceManufacturer
 {
     public static function from_json(mixed $json): DeviceDeviceManufacturer|null
@@ -602,12 +1068,24 @@ class DeviceDeviceManufacturer
     }
 
     public function __construct(
+        /**
+         * Display name for the manufacturer, such as `August`, `Yale`, `Salto`, and so on.
+         */
         public string|null $display_name,
+        /**
+         * Image URL for the manufacturer logo.
+         */
         public string|null $image_url,
+        /**
+         * Manufacturer identifier, such as `august`, `yale`, `salto`, and so on.
+         */
         public string|null $manufacturer,
     ) {}
 }
 
+/**
+ * Provider of the device. Represents the third-party service through which the device is controlled.
+ */
 class DeviceDeviceProvider
 {
     public static function from_json(mixed $json): DeviceDeviceProvider|null
@@ -624,13 +1102,28 @@ class DeviceDeviceProvider
     }
 
     public function __construct(
+        /**
+         * Device provider name. Corresponds to the integration type, such as `august`, `schlage`, `yale_access`, and so on.
+         */
         public string|null $device_provider_name,
+        /**
+         * Display name for the device provider type.
+         */
         public string|null $display_name,
+        /**
+         * Image URL for the device provider.
+         */
         public string|null $image_url,
+        /**
+         * Provider category. Indicates the third-party provider type, such as `stable`, for stable integrations, or `internal`, for internal integrations.
+         */
         public string|null $provider_category,
     ) {}
 }
 
+/**
+ * Metadata for a dormakaba Oracode device.
+ */
 class DeviceDormakabaOracodeMetadata
 {
     public static function from_json(
@@ -655,17 +1148,46 @@ class DeviceDormakabaOracodeMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a dormakaba Oracode device.
+         */
         public mixed $device_id,
+        /**
+         * Door ID for a dormakaba Oracode device.
+         */
         public float|null $door_id,
+        /**
+         * Indicates whether a door is wireless for a dormakaba Oracode device.
+         */
         public bool|null $door_is_wireless,
+        /**
+         * Door name for a dormakaba Oracode device.
+         */
         public string|null $door_name,
+        /**
+         * IANA time zone for a dormakaba Oracode device.
+         */
         public string|null $iana_timezone,
+        /**
+         * Predefined time slots for a dormakaba Oracode device.
+         */
         public array $predefined_time_slots,
+        /**
+         * Site ID for a dormakaba Oracode device.
+         *
+         * @deprecated Previously marked as "@DEPRECATED."
+         */
         public float|null $site_id,
+        /**
+         * Site name for a dormakaba Oracode device.
+         */
         public string|null $site_name,
     ) {}
 }
 
+/**
+ * Metadata for an ecobee device.
+ */
 class DeviceEcobeeMetadata
 {
     public static function from_json(mixed $json): DeviceEcobeeMetadata|null
@@ -680,11 +1202,20 @@ class DeviceEcobeeMetadata
     }
 
     public function __construct(
+        /**
+         * Device name for an ecobee device.
+         */
         public string|null $device_name,
+        /**
+         * Device ID for an ecobee device.
+         */
         public string|null $ecobee_device_id,
     ) {}
 }
 
+/**
+ * Endpoints associated with the phone.
+ */
 class DeviceEndpoints
 {
     public static function from_json(mixed $json): DeviceEndpoints|null
@@ -699,11 +1230,20 @@ class DeviceEndpoints
     }
 
     public function __construct(
+        /**
+         * ID of the associated endpoint.
+         */
         public string|null $endpoint_id,
+        /**
+         * Indicated whether the endpoint is active.
+         */
         public bool|null $is_active,
     ) {}
 }
 
+/**
+ * Array of errors associated with the device. Each error object within the array contains two fields: `error_code` and `message`. `error_code` is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+ */
 class DeviceErrors
 {
     public static function from_json(mixed $json): DeviceErrors|null
@@ -723,15 +1263,36 @@ class DeviceErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+         */
         public bool|null $is_bridge_error,
+        /**
+         * Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+         */
         public bool|null $is_connected_account_error,
+        /**
+         * Indicates that the error is not a device error.
+         */
         public bool|null $is_device_error,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Features for a TTLock device.
+ */
 class DeviceFeatures
 {
     public static function from_json(mixed $json): DeviceFeatures|null
@@ -752,16 +1313,40 @@ class DeviceFeatures
     }
 
     public function __construct(
+        /**
+         * Indicates whether a TTLock device supports auto-lock time configuration.
+         */
         public bool|null $auto_lock_time_config,
+        /**
+         * Indicates whether a TTLock device supports an incomplete keyboard passcode.
+         */
         public bool|null $incomplete_keyboard_passcode,
+        /**
+         * Indicates whether a TTLock device supports the lock command.
+         */
         public bool|null $lock_command,
+        /**
+         * Indicates whether a TTLock device supports a passcode.
+         */
         public bool|null $passcode,
+        /**
+         * Indicates whether a TTLock device supports passcode management.
+         */
         public bool|null $passcode_management,
+        /**
+         * Indicates whether a TTLock device supports unlock via gateway.
+         */
         public bool|null $unlock_via_gateway,
+        /**
+         * Indicates whether a TTLock device supports Wi-Fi.
+         */
         public bool|null $wifi,
     ) {}
 }
 
+/**
+ * Metadata for a 4SUITES device.
+ */
 class DeviceFourSuitesMetadata
 {
     public static function from_json(mixed $json): DeviceFourSuitesMetadata|null
@@ -777,12 +1362,24 @@ class DeviceFourSuitesMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a 4SUITES device.
+         */
         public float|null $device_id,
+        /**
+         * Device name for a 4SUITES device.
+         */
         public string|null $device_name,
+        /**
+         * Reclose delay, in seconds, for a 4SUITES device.
+         */
         public float|null $reclose_delay_in_seconds,
     ) {}
 }
 
+/**
+ * Metadata for a Genie device.
+ */
 class DeviceGenieMetadata
 {
     public static function from_json(mixed $json): DeviceGenieMetadata|null
@@ -797,11 +1394,20 @@ class DeviceGenieMetadata
     }
 
     public function __construct(
+        /**
+         * Lock name for a Genie device.
+         */
         public string|null $device_name,
+        /**
+         * Door name for a Genie device.
+         */
         public string|null $door_name,
     ) {}
 }
 
+/**
+ * Metadata for a Honeywell Resideo device.
+ */
 class DeviceHoneywellResideoMetadata
 {
     public static function from_json(
@@ -818,11 +1424,20 @@ class DeviceHoneywellResideoMetadata
     }
 
     public function __construct(
+        /**
+         * Device name for a Honeywell Resideo device.
+         */
         public string|null $device_name,
+        /**
+         * Device ID for a Honeywell Resideo device.
+         */
         public string|null $honeywell_resideo_device_id,
     ) {}
 }
 
+/**
+ * Latest humidity reading for a Minut device.
+ */
 class DeviceHumidity
 {
     public static function from_json(mixed $json): DeviceHumidity|null
@@ -834,11 +1449,20 @@ class DeviceHumidity
     }
 
     public function __construct(
+        /**
+         * Time of latest humidity reading for a Minut device.
+         */
         public string|null $time,
+        /**
+         * Value of latest humidity reading for a Minut device.
+         */
         public float|null $value,
     ) {}
 }
 
+/**
+ * Metadata for an igloohome device.
+ */
 class DeviceIgloohomeMetadata
 {
     public static function from_json(mixed $json): DeviceIgloohomeMetadata|null
@@ -858,15 +1482,36 @@ class DeviceIgloohomeMetadata
     }
 
     public function __construct(
+        /**
+         * Bridge ID for an igloohome device.
+         */
         public string|null $bridge_id,
+        /**
+         * Bridge name for an igloohome device.
+         */
         public string|null $bridge_name,
+        /**
+         * Device ID for an igloohome device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for an igloohome device.
+         */
         public string|null $device_name,
+        /**
+         * Indicates whether a keypad is linked to a bridge for an igloohome device.
+         */
         public bool|null $is_accessory_keypad_linked_to_bridge,
+        /**
+         * Keypad ID for an igloohome device.
+         */
         public string|null $keypad_id,
     ) {}
 }
 
+/**
+ * Metadata for an igloo device.
+ */
 class DeviceIglooMetadata
 {
     public static function from_json(mixed $json): DeviceIglooMetadata|null
@@ -882,12 +1527,24 @@ class DeviceIglooMetadata
     }
 
     public function __construct(
+        /**
+         * Bridge ID for an igloo device.
+         */
         public string|null $bridge_id,
+        /**
+         * Device ID for an igloo device.
+         */
         public string|null $device_id,
+        /**
+         * Model for an igloo device.
+         */
         public string|null $model,
     ) {}
 }
 
+/**
+ * Metadata for a KeyNest device.
+ */
 class DeviceKeynestMetadata
 {
     public static function from_json(mixed $json): DeviceKeynestMetadata|null
@@ -921,30 +1578,96 @@ class DeviceKeynestMetadata
     }
 
     public function __construct(
+        /**
+         * Address for a KeyNest device.
+         */
         public string|null $address,
+        /**
+         * Current or last store ID for a KeyNest device.
+         */
         public float|null $current_or_last_store_id,
+        /**
+         * Current status for a KeyNest device.
+         */
         public string|null $current_status,
+        /**
+         * Current user company for a KeyNest device.
+         */
         public string|null $current_user_company,
+        /**
+         * Current user email for a KeyNest device.
+         */
         public string|null $current_user_email,
+        /**
+         * Current user name for a KeyNest device.
+         */
         public string|null $current_user_name,
+        /**
+         * Current user phone number for a KeyNest device.
+         */
         public string|null $current_user_phone_number,
+        /**
+         * Default office ID for a KeyNest device.
+         */
         public float|null $default_office_id,
+        /**
+         * Device name for a KeyNest device.
+         */
         public string|null $device_name,
+        /**
+         * Fob ID for a KeyNest device.
+         */
         public float|null $fob_id,
+        /**
+         * Handover method for a KeyNest device.
+         */
         public string|null $handover_method,
+        /**
+         * Whether the KeyNest device has a photo.
+         */
         public bool|null $has_photo,
+        /**
+         * Whether the key is in a locker that does not support the access codes API.
+         */
         public bool|null $is_quadient_locker,
+        /**
+         * Key ID for a KeyNest device.
+         */
         public string|null $key_id,
+        /**
+         * Key notes for a KeyNest device.
+         */
         public string|null $key_notes,
+        /**
+         * KeyNest app user for a KeyNest device.
+         */
         public string|null $keynest_app_user,
+        /**
+         * Last movement timestamp for a KeyNest device.
+         */
         public string|null $last_movement,
+        /**
+         * Property ID for a KeyNest device.
+         */
         public string|null $property_id,
+        /**
+         * Property postcode for a KeyNest device.
+         */
         public string|null $property_postcode,
+        /**
+         * Status type for a KeyNest device.
+         */
         public string|null $status_type,
+        /**
+         * Subscription plan for a KeyNest device.
+         */
         public string|null $subscription_plan,
     ) {}
 }
 
+/**
+ * Keypad battery status.
+ */
 class DeviceKeypadBattery
 {
     public static function from_json(mixed $json): DeviceKeypadBattery|null
@@ -955,9 +1678,17 @@ class DeviceKeypadBattery
         return new self(level: $json->level ?? null);
     }
 
-    public function __construct(public float|null $level) {}
+    public function __construct(
+        /**
+         * Keypad battery charge level.
+         */
+        public float|null $level,
+    ) {}
 }
 
+/**
+ * Metadata for a Kisi device.
+ */
 class DeviceKisiMetadata
 {
     public static function from_json(mixed $json): DeviceKisiMetadata|null
@@ -974,13 +1705,28 @@ class DeviceKisiMetadata
     }
 
     public function __construct(
+        /**
+         * Description for a Kisi device.
+         */
         public string|null $description,
+        /**
+         * Lock ID for a Kisi device.
+         */
         public float|null $lock_id,
+        /**
+         * Lock name for a Kisi device.
+         */
         public string|null $lock_name,
+        /**
+         * Place name for a Kisi device.
+         */
         public string|null $place_name,
     ) {}
 }
 
+/**
+ * Metadata for a Korelock device.
+ */
 class DeviceKorelockMetadata
 {
     public static function from_json(mixed $json): DeviceKorelockMetadata|null
@@ -1000,16 +1746,40 @@ class DeviceKorelockMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a Korelock device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a Korelock device.
+         */
         public string|null $device_name,
+        /**
+         * Firmware version for a Korelock device.
+         */
         public string|null $firmware_version,
+        /**
+         * Location ID for a Korelock device. Required for timebound access codes.
+         */
         public string|null $location_id,
+        /**
+         * Model code for a Korelock device.
+         */
         public string|null $model_code,
+        /**
+         * Serial number for a Korelock device.
+         */
         public string|null $serial_number,
+        /**
+         * WiFi signal strength (0-1) for a Korelock device.
+         */
         public float|null $wifi_signal_strength,
     ) {}
 }
 
+/**
+ * Metadata for a Kwikset device.
+ */
 class DeviceKwiksetMetadata
 {
     public static function from_json(mixed $json): DeviceKwiksetMetadata|null
@@ -1025,12 +1795,24 @@ class DeviceKwiksetMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a Kwikset device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a Kwikset device.
+         */
         public string|null $device_name,
+        /**
+         * Model number for a Kwikset device.
+         */
         public string|null $model_number,
     ) {}
 }
 
+/**
+ * Latest sensor values for a Minut device.
+ */
 class DeviceLatestSensorValues
 {
     public static function from_json(mixed $json): DeviceLatestSensorValues|null
@@ -1058,14 +1840,32 @@ class DeviceLatestSensorValues
     }
 
     public function __construct(
+        /**
+         * Latest accelerometer Z-axis reading for a Minut device.
+         */
         public DeviceAccelerometerZ|null $accelerometer_z,
+        /**
+         * Latest humidity reading for a Minut device.
+         */
         public DeviceHumidity|null $humidity,
+        /**
+         * Latest pressure reading for a Minut device.
+         */
         public DevicePressure|null $pressure,
+        /**
+         * Latest sound reading for a Minut device.
+         */
         public DeviceSound|null $sound,
+        /**
+         * Latest temperature reading for a Minut device.
+         */
         public DeviceTemperature|null $temperature,
     ) {}
 }
 
+/**
+ * Location information for the device.
+ */
 class DeviceLocation
 {
     public static function from_json(mixed $json): DeviceLocation|null
@@ -1081,12 +1881,26 @@ class DeviceLocation
     }
 
     public function __construct(
+        /**
+         * Name of the device location.
+         */
         public string|null $location_name,
+        /**
+         * Time zone of the device location.
+         */
         public string|null $time_zone,
+        /**
+         * Time zone of the device location.
+         *
+         * @deprecated Use `time_zone` instead.
+         */
         public string|null $timezone,
     ) {}
 }
 
+/**
+ * Metadata for a Lockly device.
+ */
 class DeviceLocklyMetadata
 {
     public static function from_json(mixed $json): DeviceLocklyMetadata|null
@@ -1102,12 +1916,24 @@ class DeviceLocklyMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a Lockly device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a Lockly device.
+         */
         public string|null $device_name,
+        /**
+         * Model for a Lockly device.
+         */
         public string|null $model,
     ) {}
 }
 
+/**
+ * Metadata for a Minut device.
+ */
 class DeviceMinutMetadata
 {
     public static function from_json(mixed $json): DeviceMinutMetadata|null
@@ -1127,12 +1953,24 @@ class DeviceMinutMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a Minut device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a Minut device.
+         */
         public string|null $device_name,
+        /**
+         * Latest sensor values for a Minut device.
+         */
         public DeviceLatestSensorValues|null $latest_sensor_values,
     ) {}
 }
 
+/**
+ * Device model-related properties.
+ */
 class DeviceModel
 {
     public static function from_json(mixed $json): DeviceModel|null
@@ -1156,16 +1994,40 @@ class DeviceModel
     }
 
     public function __construct(
+        /**
+         * @deprecated use device.properties.model.can_connect_accessory_keypad
+         */
         public bool|null $accessory_keypad_supported,
+        /**
+         * Indicates whether the device can connect a accessory keypad.
+         */
         public bool|null $can_connect_accessory_keypad,
+        /**
+         * Display name of the device model.
+         */
         public string|null $display_name,
+        /**
+         * Indicates whether the device has a built in accessory keypad.
+         */
         public bool|null $has_built_in_keypad,
+        /**
+         * Display name that corresponds to the manufacturer-specific terminology for the device.
+         */
         public string|null $manufacturer_display_name,
+        /**
+         * @deprecated use device.can_program_offline_access_codes.
+         */
         public bool|null $offline_access_codes_supported,
+        /**
+         * @deprecated use device.can_program_online_access_codes.
+         */
         public bool|null $online_access_codes_supported,
     ) {}
 }
 
+/**
+ * Metadata for a Google Nest device.
+ */
 class DeviceNestMetadata
 {
     public static function from_json(mixed $json): DeviceNestMetadata|null
@@ -1182,13 +2044,28 @@ class DeviceNestMetadata
     }
 
     public function __construct(
+        /**
+         * Custom device name for a Google Nest device. The device owner sets this value.
+         */
         public string|null $device_custom_name,
+        /**
+         * Device name for a Google Nest device. Google sets this value.
+         */
         public string|null $device_name,
+        /**
+         * Display name for a Google Nest device.
+         */
         public string|null $display_name,
+        /**
+         * Device ID for a Google Nest device.
+         */
         public string|null $nest_device_id,
     ) {}
 }
 
+/**
+ * Metadata for a NoiseAware device.
+ */
 class DeviceNoiseawareMetadata
 {
     public static function from_json(mixed $json): DeviceNoiseawareMetadata|null
@@ -1206,14 +2083,32 @@ class DeviceNoiseawareMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a NoiseAware device.
+         */
         public string|null $device_id,
+        /**
+         * Device model for a NoiseAware device.
+         */
         public string|null $device_model,
+        /**
+         * Device name for a NoiseAware device.
+         */
         public string|null $device_name,
+        /**
+         * Noise level, in decibels, for a NoiseAware device.
+         */
         public float|null $noise_level_decibel,
+        /**
+         * Noise level, expressed as a Noise Risk Score (NRS), for a NoiseAware device.
+         */
         public float|null $noise_level_nrs,
     ) {}
 }
 
+/**
+ * Metadata for a Nuki device.
+ */
 class DeviceNukiMetadata
 {
     public static function from_json(mixed $json): DeviceNukiMetadata|null
@@ -1231,14 +2126,32 @@ class DeviceNukiMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a Nuki device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a Nuki device.
+         */
         public string|null $device_name,
+        /**
+         * Indicates whether keypad 2 is paired for a Nuki device.
+         */
         public bool|null $keypad_2_paired,
+        /**
+         * Indicates whether the keypad battery is in a critical state for a Nuki device.
+         */
         public bool|null $keypad_battery_critical,
+        /**
+         * Indicates whether the keypad is paired for a Nuki device.
+         */
         public bool|null $keypad_paired,
     ) {}
 }
 
+/**
+ * Time frames that may be requested when creating an offline access code, expressed as a list of options. The caller picks one option (by matching the requested duration when the options' duration ranges do not overlap, or by `display_name` when they do) and satisfies that one option's rules. When `undefined`, any time frame works.
+ */
 class DeviceOfflineTimeFrameOptions
 {
     public static function from_json(
@@ -1264,17 +2177,44 @@ class DeviceOfflineTimeFrameOptions
     }
 
     public function __construct(
+        /**
+         * Label for this option. For a single-option device, the product name (for example, `algoPIN` or `SmartPIN`); for a multi-option device, a label that distinguishes it (for example, `Hourly` or `Fixed start times`).
+         */
         public string|null $display_name,
+        /**
+         * iCalendar recurrence rule (RRULE) that the end date must fall on. Constrains which calendar dates are selectable, independent of the time-of-day rules.
+         */
         public string|null $end_date_recurrence_rule,
+        /**
+         * When `true`, the start and end must fall at the same time of day (the caller picks which). Mutually exclusive with `time_pairs`.
+         */
         public bool|null $matching_start_end_time,
+        /**
+         * Maximum duration this option covers, as an ISO 8601 duration (for example, `PT672H` or `P367D`). Omitted when there is no maximum.
+         */
         public string|null $max_duration,
+        /**
+         * Minimum duration this option covers, as an ISO 8601 duration (for example, `PT1H` or `P29D`). Omitted when there is no minimum.
+         */
         public string|null $min_duration,
+        /**
+         * iCalendar recurrence rule (RRULE) that the start date must fall on (for example, `FREQ=MONTHLY;BYDAY=1MO,3MO`). Constrains which calendar dates are selectable, independent of the time-of-day rules.
+         */
         public string|null $start_date_recurrence_rule,
+        /**
+         * Fixed start/end time pairings the caller chooses from. Mutually exclusive with `matching_start_end_time`.
+         */
         public array $time_pairs,
+        /**
+         * IANA time zone for interpreting `time_pairs` and the date recurrence rules. Present only when the option fixes times or dates.
+         */
         public string|null $time_zone,
     ) {}
 }
 
+/**
+ * Metadata for an Omnitec device.
+ */
 class DeviceOmnitecMetadata
 {
     public static function from_json(mixed $json): DeviceOmnitecMetadata|null
@@ -1294,16 +2234,40 @@ class DeviceOmnitecMetadata
     }
 
     public function __construct(
+        /**
+         * Whether the Omnitec lock has a connected gateway for remote operations.
+         */
         public bool|null $has_gateway,
+        /**
+         * Operator-assigned alias for an Omnitec device.
+         */
         public string|null $lock_alias,
+        /**
+         * Lock ID for an Omnitec device.
+         */
         public float|null $lock_id,
+        /**
+         * Bluetooth MAC address for an Omnitec device.
+         */
         public string|null $lock_mac,
+        /**
+         * Lock name for an Omnitec device.
+         */
         public string|null $lock_name,
+        /**
+         * IANA time zone for the Omnitec device, used to schedule time-bound access codes at the correct local time (accounting for DST).
+         */
         public string|null $time_zone,
+        /**
+         * Static UTC offset of the Omnitec lock in milliseconds. Does not account for DST.
+         */
         public float|null $timezone_raw_offset_ms,
     ) {}
 }
 
+/**
+ * Time frames that may be requested when creating an online access code, expressed as a list of options. The caller picks one option (by matching the requested duration when the options' duration ranges do not overlap, or by `display_name` when they do) and satisfies that one option's rules. When `undefined`, any time frame works.
+ */
 class DeviceOnlineTimeFrameOptions
 {
     public static function from_json(
@@ -1329,17 +2293,44 @@ class DeviceOnlineTimeFrameOptions
     }
 
     public function __construct(
+        /**
+         * Label for this option. For a single-option device, the product name (for example, `algoPIN` or `SmartPIN`); for a multi-option device, a label that distinguishes it (for example, `Hourly` or `Fixed start times`).
+         */
         public string|null $display_name,
+        /**
+         * iCalendar recurrence rule (RRULE) that the end date must fall on. Constrains which calendar dates are selectable, independent of the time-of-day rules.
+         */
         public string|null $end_date_recurrence_rule,
+        /**
+         * When `true`, the start and end must fall at the same time of day (the caller picks which). Mutually exclusive with `time_pairs`.
+         */
         public bool|null $matching_start_end_time,
+        /**
+         * Maximum duration this option covers, as an ISO 8601 duration (for example, `PT672H` or `P367D`). Omitted when there is no maximum.
+         */
         public string|null $max_duration,
+        /**
+         * Minimum duration this option covers, as an ISO 8601 duration (for example, `PT1H` or `P29D`). Omitted when there is no minimum.
+         */
         public string|null $min_duration,
+        /**
+         * iCalendar recurrence rule (RRULE) that the start date must fall on (for example, `FREQ=MONTHLY;BYDAY=1MO,3MO`). Constrains which calendar dates are selectable, independent of the time-of-day rules.
+         */
         public string|null $start_date_recurrence_rule,
+        /**
+         * Fixed start/end time pairings the caller chooses from. Mutually exclusive with `matching_start_end_time`.
+         */
         public array $time_pairs,
+        /**
+         * IANA time zone for interpreting `time_pairs` and the date recurrence rules. Present only when the option fixes times or dates.
+         */
         public string|null $time_zone,
     ) {}
 }
 
+/**
+ * Array of thermostat daily program periods.
+ */
 class DevicePeriods
 {
     public static function from_json(mixed $json): DevicePeriods|null
@@ -1354,11 +2345,20 @@ class DevicePeriods
     }
 
     public function __construct(
+        /**
+         * Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.
+         */
         public string|null $climate_preset_key,
+        /**
+         * Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $starts_at_time,
     ) {}
 }
 
+/**
+ * Predefined time slots for a dormakaba Oracode device.
+ */
 class DevicePredefinedTimeSlots
 {
     public static function from_json(
@@ -1384,19 +2384,52 @@ class DevicePredefinedTimeSlots
     }
 
     public function __construct(
+        /**
+         * Check in time for a time slot for a dormakaba Oracode device.
+         */
         public string|null $check_in_time,
+        /**
+         * Checkout time for a time slot for a dormakaba Oracode device.
+         */
         public string|null $check_out_time,
+        /**
+         * ID of a user level for a dormakaba Oracode device.
+         */
         public string|null $dormakaba_oracode_user_level_id,
+        /**
+         * Prefix for a user level for a dormakaba Oracode device.
+         */
         public float|null $dormakaba_oracode_user_level_prefix,
+        /**
+         * Indicates whether a time slot for a dormakaba Oracode device is a 24-hour time slot.
+         */
         public bool|null $is_24_hour,
+        /**
+         * Indicates whether a time slot for a dormakaba Oracode device is in biweekly mode.
+         */
         public bool|null $is_biweekly_mode,
+        /**
+         * Indicates whether a time slot for a dormakaba Oracode device is a master time slot.
+         */
         public bool|null $is_master,
+        /**
+         * Indicates whether a time slot for a dormakaba Oracode device is a one-shot time slot.
+         */
         public bool|null $is_one_shot,
+        /**
+         * Name of a time slot for a dormakaba Oracode device.
+         */
         public string|null $name,
+        /**
+         * Prefix for a time slot for a dormakaba Oracode device.
+         */
         public float|null $prefix,
     ) {}
 }
 
+/**
+ * Latest pressure reading for a Minut device.
+ */
 class DevicePressure
 {
     public static function from_json(mixed $json): DevicePressure|null
@@ -1408,11 +2441,20 @@ class DevicePressure
     }
 
     public function __construct(
+        /**
+         * Time of latest pressure reading for a Minut device.
+         */
         public string|null $time,
+        /**
+         * Value of latest pressure reading for a Minut device.
+         */
         public float|null $value,
     ) {}
 }
 
+/**
+ * Properties of the device.
+ */
 class DeviceProperties
 {
     public static function from_json(mixed $json): DeviceProperties|null
@@ -1708,113 +2750,438 @@ class DeviceProperties
     }
 
     public function __construct(
+        /**
+         * Accessory keypad properties and state.
+         */
         public DeviceAccessoryKeypad|null $accessory_keypad,
+        /**
+         * Active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         *
+         * @deprecated Use `active_thermostat_schedule_id` with `/thermostats/schedules/get` instead.
+         */
         public DeviceActiveThermostatSchedule|null $active_thermostat_schedule,
+        /**
+         * ID of the active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         */
         public string|null $active_thermostat_schedule_id,
+        /**
+         * Metadata for an Akiles device.
+         */
         public DeviceAkilesMetadata|null $akiles_metadata,
+        /**
+         * Appearance-related properties, as reported by the device.
+         */
         public DeviceAppearance|null $appearance,
+        /**
+         * Metadata for an Aqara device.
+         */
         public DeviceAqaraMetadata|null $aqara_metadata,
+        /**
+         * ASSA ABLOY Credential Service metadata for the phone.
+         */
         public DeviceAssaAbloyCredentialServiceMetadata|null $assa_abloy_credential_service_metadata,
+        /**
+         * Metadata for an ASSA ABLOY Vostio system.
+         */
         public DeviceAssaAbloyVostioMetadata|null $assa_abloy_vostio_metadata,
+        /**
+         * Metadata for an August device.
+         */
         public DeviceAugustMetadata|null $august_metadata,
+        /**
+         * The delay in seconds before the lock automatically locks after being unlocked.
+         */
         public float|null $auto_lock_delay_seconds,
+        /**
+         * Indicates whether automatic locking is enabled.
+         */
         public bool|null $auto_lock_enabled,
+        /**
+         * Climate preset modes that the thermostat supports, such as "home", "away", "wake", "sleep", "occupied", and "unoccupied".
+         */
         public array|null $available_climate_preset_modes,
+        /**
+         * Available [climate presets](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for the thermostat.
+         */
         public array $available_climate_presets,
+        /**
+         * Fan mode settings that the thermostat supports.
+         */
         public array|null $available_fan_mode_settings,
+        /**
+         * HVAC mode settings that the thermostat supports.
+         */
         public array|null $available_hvac_mode_settings,
+        /**
+         * Metadata for an Avigilon Alta system.
+         */
         public DeviceAvigilonAltaMetadata|null $avigilon_alta_metadata,
+        /**
+         * Indicates whether the [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) is currently enabled for the device. To disable it, set this to `false` using [/devices/update](https://docs.seam.co/api/devices/update).
+         */
         public bool|null $backup_access_code_pool_enabled,
+        /**
+         * Represents the current status of the battery charge level.
+         */
         public DeviceBattery|null $battery,
+        /**
+         * Indicates the battery level of the device as a decimal value between 0 and 1, inclusive.
+         */
         public float|null $battery_level,
+        /**
+         * Metadata for a Brivo device.
+         */
         public DeviceBrivoMetadata|null $brivo_metadata,
+        /**
+         * Constraints on access codes for the device. Seam represents each constraint as an object with a `constraint_type` property. Depending on the constraint type, there may also be additional properties. Note that some constraints are manufacturer- or device-specific.
+         */
         public array $code_constraints,
+        /**
+         * Metadata for a ControlByWeb device.
+         */
         public DeviceControlbywebMetadata|null $controlbyweb_metadata,
+        /**
+         * Current climate setting.
+         */
         public DeviceCurrentClimateSetting|null $current_climate_setting,
+        /**
+         * Array of noise threshold IDs that are currently triggering.
+         */
         public array|null $currently_triggering_noise_threshold_ids,
+        /**
+         * @deprecated use fallback_climate_preset_key to specify a fallback climate preset instead.
+         */
         public DeviceDefaultClimateSetting|null $default_climate_setting,
+        /**
+         * Indicates whether the door is open.
+         */
         public bool|null $door_open,
+        /**
+         * Metadata for a dormakaba Oracode device.
+         */
         public DeviceDormakabaOracodeMetadata|null $dormakaba_oracode_metadata,
+        /**
+         * Metadata for an ecobee device.
+         */
         public DeviceEcobeeMetadata|null $ecobee_metadata,
+        /**
+         * Key of the [fallback climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) for the thermostat.
+         */
         public string|null $fallback_climate_preset_key,
+        /**
+         * @deprecated Use `current_climate_setting.fan_mode_setting` instead.
+         */
         public string|null $fan_mode_setting,
+        /**
+         * Metadata for a 4SUITES device.
+         */
         public DeviceFourSuitesMetadata|null $four_suites_metadata,
+        /**
+         * Metadata for a Genie device.
+         */
         public DeviceGenieMetadata|null $genie_metadata,
+        /**
+         * Indicates whether the device has direct power.
+         */
         public bool|null $has_direct_power,
+        /**
+         * Indicates whether the device supports native entry events.
+         */
         public bool|null $has_native_entry_events,
+        /**
+         * Metadata for a Honeywell Resideo device.
+         */
         public DeviceHoneywellResideoMetadata|null $honeywell_resideo_metadata,
+        /**
+         * Metadata for an igloo device.
+         */
         public DeviceIglooMetadata|null $igloo_metadata,
+        /**
+         * Metadata for an igloohome device.
+         */
         public DeviceIgloohomeMetadata|null $igloohome_metadata,
+        /**
+         * Alt text for the device image.
+         */
         public string|null $image_alt_text,
+        /**
+         * Image URL for the device.
+         */
         public string|null $image_url,
+        /**
+         * Indicates whether the connected HVAC system is currently cooling, as reported by the thermostat.
+         */
         public bool|null $is_cooling,
+        /**
+         * Indicates whether the fan in the connected HVAC system is currently running, as reported by the thermostat.
+         */
         public bool|null $is_fan_running,
+        /**
+         * Indicates whether the connected HVAC system is currently heating, as reported by the thermostat.
+         */
         public bool|null $is_heating,
+        /**
+         * Indicates whether the current thermostat settings differ from the most recent active program or schedule that Seam activated. For this condition to occur, `current_climate_setting.manual_override_allowed` must also be `true`.
+         */
         public bool|null $is_temporary_manual_override_active,
+        /**
+         * Metadata for a KeyNest device.
+         */
         public DeviceKeynestMetadata|null $keynest_metadata,
+        /**
+         * Keypad battery status.
+         */
         public DeviceKeypadBattery|null $keypad_battery,
+        /**
+         * Metadata for a Kisi device.
+         */
         public DeviceKisiMetadata|null $kisi_metadata,
+        /**
+         * Metadata for a Korelock device.
+         */
         public DeviceKorelockMetadata|null $korelock_metadata,
+        /**
+         * Metadata for a Kwikset device.
+         */
         public DeviceKwiksetMetadata|null $kwikset_metadata,
+        /**
+         * Indicates whether the lock is locked.
+         */
         public bool|null $locked,
+        /**
+         * Metadata for a Lockly device.
+         */
         public DeviceLocklyMetadata|null $lockly_metadata,
+        /**
+         * Manufacturer of the device. When a device, such as a smart lock, is connected through a smart hub, the manufacturer of the device might be different from that of the smart hub.
+         */
         public string|null $manufacturer,
+        /**
+         * Maximum number of active access codes that the device supports.
+         */
         public float|null $max_active_codes_supported,
+        /**
+         * Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
+         */
         public float|null $max_cooling_set_point_celsius,
+        /**
+         * Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
+         */
         public float|null $max_cooling_set_point_fahrenheit,
+        /**
+         * Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
+         */
         public float|null $max_heating_set_point_celsius,
+        /**
+         * Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
+         */
         public float|null $max_heating_set_point_fahrenheit,
+        /**
+         * Maximum number of periods that the thermostat can support per day. For example, if the thermostat supports 4 periods per day, this value is 4.
+         */
         public float|null $max_thermostat_daily_program_periods_per_day,
+        /**
+         * Maximum number of climate presets that the thermostat can support for weekly programming.
+         */
         public float|null $max_unique_climate_presets_per_thermostat_weekly_program,
+        /**
+         * Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
+         */
         public float|null $min_cooling_set_point_celsius,
+        /**
+         * Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
+         */
         public float|null $min_cooling_set_point_fahrenheit,
+        /**
+         * Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °C between the cooling and heating set points when in heat-cool (auto) mode.
+         */
         public float|null $min_heating_cooling_delta_celsius,
+        /**
+         * Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °F between the cooling and heating set points when in heat-cool (auto) mode.
+         */
         public float|null $min_heating_cooling_delta_fahrenheit,
+        /**
+         * Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
+         */
         public float|null $min_heating_set_point_celsius,
+        /**
+         * Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
+         */
         public float|null $min_heating_set_point_fahrenheit,
+        /**
+         * Metadata for a Minut device.
+         */
         public DeviceMinutMetadata|null $minut_metadata,
+        /**
+         * Device model-related properties.
+         */
         public DeviceModel|null $model,
+        /**
+         * Name of the device.
+         *
+         * @deprecated use device.display_name instead
+         */
         public string|null $name,
+        /**
+         * Metadata for a Google Nest device.
+         */
         public DeviceNestMetadata|null $nest_metadata,
+        /**
+         * Indicates current noise level in decibels, if the device supports noise detection.
+         */
         public float|null $noise_level_decibels,
+        /**
+         * Metadata for a NoiseAware device.
+         */
         public DeviceNoiseawareMetadata|null $noiseaware_metadata,
+        /**
+         * Metadata for a Nuki device.
+         */
         public DeviceNukiMetadata|null $nuki_metadata,
+        /**
+         * Indicates whether it is currently possible to use offline access codes for the device.
+         *
+         * @deprecated use device.can_program_offline_access_codes
+         */
         public bool|null $offline_access_codes_enabled,
+        /**
+         * Time frames that may be requested when creating an offline access code, expressed as a list of options. The caller picks one option (by matching the requested duration when the options' duration ranges do not overlap, or by `display_name` when they do) and satisfies that one option's rules. When `undefined`, any time frame works.
+         */
         public array $offline_time_frame_options,
+        /**
+         * Metadata for an Omnitec device.
+         */
         public DeviceOmnitecMetadata|null $omnitec_metadata,
+        /**
+         * Indicates whether the device is online.
+         */
         public bool|null $online,
+        /**
+         * Indicates whether it is currently possible to use online access codes for the device.
+         *
+         * @deprecated use device.can_program_online_access_codes
+         */
         public bool|null $online_access_codes_enabled,
+        /**
+         * Time frames that may be requested when creating an online access code, expressed as a list of options. The caller picks one option (by matching the requested duration when the options' duration ranges do not overlap, or by `display_name` when they do) and satisfies that one option's rules. When `undefined`, any time frame works.
+         */
         public array $online_time_frame_options,
+        /**
+         * Reported relative humidity, as a value between 0 and 1, inclusive.
+         */
         public float|null $relative_humidity,
+        /**
+         * Metadata for a Ring device.
+         */
         public DeviceRingMetadata|null $ring_metadata,
+        /**
+         * Metadata for a Salto KS device.
+         */
         public DeviceSaltoKsMetadata|null $salto_ks_metadata,
+        /**
+         * Metada for a Salto device.
+         *
+         * @deprecated Use `salto_ks_metadata ` instead.
+         */
         public DeviceSaltoMetadata|null $salto_metadata,
+        /**
+         * Salto Space credential service metadata for the phone.
+         */
         public DeviceSaltoSpaceCredentialServiceMetadata|null $salto_space_credential_service_metadata,
+        /**
+         * Metadata for a Schlage device.
+         */
         public DeviceSchlageMetadata|null $schlage_metadata,
+        /**
+         * Metadata for Seam Bridge.
+         */
         public DeviceSeamBridgeMetadata|null $seam_bridge_metadata,
+        /**
+         * Metadata for a Sensi device.
+         */
         public DeviceSensiMetadata|null $sensi_metadata,
+        /**
+         * Serial number of the device.
+         */
         public string|null $serial_number,
+        /**
+         * Metadata for a SmartThings device.
+         */
         public DeviceSmartthingsMetadata|null $smartthings_metadata,
+        /**
+         * Supported code lengths for access codes.
+         */
         public array|null $supported_code_lengths,
+        /**
+         * @deprecated use device.properties.model.can_connect_accessory_keypad
+         */
         public bool|null $supports_accessory_keypad,
+        /**
+         * Indicates whether the device supports a [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes).
+         */
         public bool|null $supports_backup_access_code_pool,
+        /**
+         * @deprecated use offline_access_codes_enabled
+         */
         public bool|null $supports_offline_access_codes,
+        /**
+         * Metadata for a tado° device.
+         */
         public DeviceTadoMetadata|null $tado_metadata,
+        /**
+         * Metadata for a Tedee device.
+         */
         public DeviceTedeeMetadata|null $tedee_metadata,
+        /**
+         * Reported temperature in °C.
+         */
         public float|null $temperature_celsius,
+        /**
+         * Reported temperature in °F.
+         */
         public float|null $temperature_fahrenheit,
+        /**
+         * Current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+         */
         public DeviceTemperatureThreshold|null $temperature_threshold,
+        /**
+         * Precision of the thermostat's period in minutes. For example, if the thermostat supports 15-minute periods, this value is 15. All values are relative to the top of the hour, so for 15 minutes, the periods would be 0, 15, 30, and 45 minutes past the hour.
+         */
         public float|null $thermostat_daily_program_period_precision_minutes,
+        /**
+         * Configured [daily programs](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
+         */
         public array $thermostat_daily_programs,
+        /**
+         * Current [weekly program](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
+         */
         public DeviceThermostatWeeklyProgram|null $thermostat_weekly_program,
+        /**
+         * Metadata for a TTLock device.
+         */
         public DeviceTtlockMetadata|null $ttlock_metadata,
+        /**
+         * Metadata for a 2N device.
+         */
         public DeviceTwoNMetadata|null $two_n_metadata,
+        /**
+         * Metadata for an Ultraloq device.
+         */
         public DeviceUltraloqMetadata|null $ultraloq_metadata,
+        /**
+         * Metadata for an ASSA ABLOY Visionline system.
+         */
         public DeviceVisionlineMetadata|null $visionline_metadata,
+        /**
+         * Metadata for a Wyze device.
+         */
         public DeviceWyzeMetadata|null $wyze_metadata,
     ) {}
 }
 
+/**
+ * Metadata for a Ring device.
+ */
 class DeviceRingMetadata
 {
     public static function from_json(mixed $json): DeviceRingMetadata|null
@@ -1829,11 +3196,20 @@ class DeviceRingMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a Ring device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a Ring device.
+         */
         public string|null $device_name,
     ) {}
 }
 
+/**
+ * Metadata for a Salto KS device.
+ */
 class DeviceSaltoKsMetadata
 {
     public static function from_json(mixed $json): DeviceSaltoKsMetadata|null
@@ -1856,18 +3232,48 @@ class DeviceSaltoKsMetadata
     }
 
     public function __construct(
+        /**
+         * Battery level for a Salto KS device.
+         */
         public string|null $battery_level,
+        /**
+         * Customer reference for a Salto KS device.
+         */
         public string|null $customer_reference,
+        /**
+         * Indicates whether the site has a Salto KS subscription that supports custom PINs.
+         */
         public bool|null $has_custom_pin_subscription,
+        /**
+         * Lock ID for a Salto KS device.
+         */
         public string|null $lock_id,
+        /**
+         * Lock type for a Salto KS device.
+         */
         public string|null $lock_type,
+        /**
+         * Locked state for a Salto KS device.
+         */
         public string|null $locked_state,
+        /**
+         * Model for a Salto KS device.
+         */
         public string|null $model,
+        /**
+         * Site ID for the Salto KS site to which the device belongs.
+         */
         public string|null $site_id,
+        /**
+         * Site name for the Salto KS site to which the device belongs.
+         */
         public string|null $site_name,
     ) {}
 }
 
+/**
+ * Metada for a Salto device.
+ */
 class DeviceSaltoMetadata
 {
     public static function from_json(mixed $json): DeviceSaltoMetadata|null
@@ -1888,17 +3294,44 @@ class DeviceSaltoMetadata
     }
 
     public function __construct(
+        /**
+         * Battery level for a Salto device.
+         */
         public string|null $battery_level,
+        /**
+         * Customer reference for a Salto device.
+         */
         public string|null $customer_reference,
+        /**
+         * Lock ID for a Salto device.
+         */
         public string|null $lock_id,
+        /**
+         * Lock type for a Salto device.
+         */
         public string|null $lock_type,
+        /**
+         * Locked state for a Salto device.
+         */
         public string|null $locked_state,
+        /**
+         * Model for a Salto device.
+         */
         public string|null $model,
+        /**
+         * Site ID for the Salto KS site to which the device belongs.
+         */
         public string|null $site_id,
+        /**
+         * Site name for the Salto KS site to which the device belongs.
+         */
         public string|null $site_name,
     ) {}
 }
 
+/**
+ * Salto Space credential service metadata for the phone.
+ */
 class DeviceSaltoSpaceCredentialServiceMetadata
 {
     public static function from_json(
@@ -1910,9 +3343,17 @@ class DeviceSaltoSpaceCredentialServiceMetadata
         return new self(has_active_phone: $json->has_active_phone ?? null);
     }
 
-    public function __construct(public bool|null $has_active_phone) {}
+    public function __construct(
+        /**
+         * Indicates whether the credential service has an active associated phone.
+         */
+        public bool|null $has_active_phone,
+    ) {}
 }
 
+/**
+ * Metadata for a Schlage device.
+ */
 class DeviceSchlageMetadata
 {
     public static function from_json(mixed $json): DeviceSchlageMetadata|null
@@ -1928,12 +3369,24 @@ class DeviceSchlageMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a Schlage device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a Schlage device.
+         */
         public string|null $device_name,
+        /**
+         * Model for a Schlage device.
+         */
         public string|null $model,
     ) {}
 }
 
+/**
+ * Metadata for Seam Bridge.
+ */
 class DeviceSeamBridgeMetadata
 {
     public static function from_json(mixed $json): DeviceSeamBridgeMetadata|null
@@ -1949,12 +3402,24 @@ class DeviceSeamBridgeMetadata
     }
 
     public function __construct(
+        /**
+         * Device number for Seam Bridge.
+         */
         public float|null $device_num,
+        /**
+         * Name for Seam Bridge.
+         */
         public string|null $name,
+        /**
+         * Unlock method for Seam Bridge.
+         */
         public string|null $unlock_method,
     ) {}
 }
 
+/**
+ * Metadata for a Sensi device.
+ */
 class DeviceSensiMetadata
 {
     public static function from_json(mixed $json): DeviceSensiMetadata|null
@@ -1972,13 +3437,28 @@ class DeviceSensiMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a Sensi device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a Sensi device.
+         */
         public string|null $device_name,
+        /**
+         * Set to true when the device does not support the /dual-setpoints API endpoint.
+         */
         public bool|null $dual_setpoints_not_supported,
+        /**
+         * Product type for a Sensi device.
+         */
         public string|null $product_type,
     ) {}
 }
 
+/**
+ * Metadata for a SmartThings device.
+ */
 class DeviceSmartthingsMetadata
 {
     public static function from_json(
@@ -1996,13 +3476,28 @@ class DeviceSmartthingsMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a SmartThings device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for a SmartThings device.
+         */
         public string|null $device_name,
+        /**
+         * Location ID for a SmartThings device.
+         */
         public string|null $location_id,
+        /**
+         * Model for a SmartThings device.
+         */
         public string|null $model,
     ) {}
 }
 
+/**
+ * Latest sound reading for a Minut device.
+ */
 class DeviceSound
 {
     public static function from_json(mixed $json): DeviceSound|null
@@ -2014,11 +3509,20 @@ class DeviceSound
     }
 
     public function __construct(
+        /**
+         * Time of latest sound reading for a Minut device.
+         */
         public string|null $time,
+        /**
+         * Value of latest sound reading for a Minut device.
+         */
         public float|null $value,
     ) {}
 }
 
+/**
+ * Metadata for a tado° device.
+ */
 class DeviceTadoMetadata
 {
     public static function from_json(mixed $json): DeviceTadoMetadata|null
@@ -2033,11 +3537,20 @@ class DeviceTadoMetadata
     }
 
     public function __construct(
+        /**
+         * Device type for a tado° device.
+         */
         public string|null $device_type,
+        /**
+         * Serial number for a tado° device.
+         */
         public string|null $serial_no,
     ) {}
 }
 
+/**
+ * Metadata for a Tedee device.
+ */
 class DeviceTedeeMetadata
 {
     public static function from_json(mixed $json): DeviceTedeeMetadata|null
@@ -2057,16 +3570,40 @@ class DeviceTedeeMetadata
     }
 
     public function __construct(
+        /**
+         * Bridge ID for a Tedee device.
+         */
         public float|null $bridge_id,
+        /**
+         * Bridge name for a Tedee device.
+         */
         public string|null $bridge_name,
+        /**
+         * Device ID for a Tedee device.
+         */
         public float|null $device_id,
+        /**
+         * Device model for a Tedee device.
+         */
         public string|null $device_model,
+        /**
+         * Device name for a Tedee device.
+         */
         public string|null $device_name,
+        /**
+         * Keypad ID for a Tedee device.
+         */
         public float|null $keypad_id,
+        /**
+         * Serial number for a Tedee device.
+         */
         public string|null $serial_number,
     ) {}
 }
 
+/**
+ * Latest temperature reading for a Minut device.
+ */
 class DeviceTemperature
 {
     public static function from_json(mixed $json): DeviceTemperature|null
@@ -2078,11 +3615,20 @@ class DeviceTemperature
     }
 
     public function __construct(
+        /**
+         * Time of latest temperature reading for a Minut device.
+         */
         public string|null $time,
+        /**
+         * Value of latest temperature reading for a Minut device.
+         */
         public float|null $value,
     ) {}
 }
 
+/**
+ * Current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+ */
 class DeviceTemperatureThreshold
 {
     public static function from_json(
@@ -2100,13 +3646,28 @@ class DeviceTemperatureThreshold
     }
 
     public function __construct(
+        /**
+         * Lower limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+         */
         public float|null $lower_limit_celsius,
+        /**
+         * Lower limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+         */
         public float|null $lower_limit_fahrenheit,
+        /**
+         * Upper limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+         */
         public float|null $upper_limit_celsius,
+        /**
+         * Upper limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+         */
         public float|null $upper_limit_fahrenheit,
     ) {}
 }
 
+/**
+ * Configured [daily programs](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
+ */
 class DeviceThermostatDailyPrograms
 {
     public static function from_json(
@@ -2130,15 +3691,36 @@ class DeviceThermostatDailyPrograms
     }
 
     public function __construct(
+        /**
+         * Date and time at which the thermostat daily program was created.
+         */
         public string|null $created_at,
+        /**
+         * ID of the thermostat device on which the thermostat daily program is configured.
+         */
         public string|null $device_id,
+        /**
+         * User-friendly name to identify the thermostat daily program.
+         */
         public string|null $name,
+        /**
+         * Array of thermostat daily program periods.
+         */
         public array $periods,
+        /**
+         * ID of the thermostat daily program.
+         */
         public string|null $thermostat_daily_program_id,
+        /**
+         * ID of the workspace that contains the thermostat daily program.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Current [weekly program](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
+ */
 class DeviceThermostatWeeklyProgram
 {
     public static function from_json(
@@ -2160,17 +3742,44 @@ class DeviceThermostatWeeklyProgram
     }
 
     public function __construct(
+        /**
+         * Date and time at which the thermostat weekly program was created.
+         */
         public string|null $created_at,
+        /**
+         * ID of the thermostat daily program to run on Fridays.
+         */
         public string|null $friday_program_id,
+        /**
+         * ID of the thermostat daily program to run on Mondays.
+         */
         public string|null $monday_program_id,
+        /**
+         * ID of the thermostat daily program to run on Saturdays.
+         */
         public string|null $saturday_program_id,
+        /**
+         * ID of the thermostat daily program to run on Sundays.
+         */
         public string|null $sunday_program_id,
+        /**
+         * ID of the thermostat daily program to run on Thursdays.
+         */
         public string|null $thursday_program_id,
+        /**
+         * ID of the thermostat daily program to run on Tuesdays.
+         */
         public string|null $tuesday_program_id,
+        /**
+         * ID of the thermostat daily program to run on Wednesdays.
+         */
         public string|null $wednesday_program_id,
     ) {}
 }
 
+/**
+ * Fixed start/end time pairings the caller chooses from. Mutually exclusive with `matching_start_end_time`.
+ */
 class DeviceTimePairs
 {
     public static function from_json(mixed $json): DeviceTimePairs|null
@@ -2186,12 +3795,24 @@ class DeviceTimePairs
     }
 
     public function __construct(
+        /**
+         * Label for the start/end time pairing.
+         */
         public string|null $display_name,
+        /**
+         * End time of day as a 24-hour `HH:MM` value, interpreted in the option's `time_zone`. An `end_time` earlier on the clock than `start_time` means the end falls on a later date.
+         */
         public string|null $end_time,
+        /**
+         * Start time of day as a 24-hour `HH:MM` value, interpreted in the option's `time_zone`.
+         */
         public string|null $start_time,
     ) {}
 }
 
+/**
+ * Metadata for a TTLock device.
+ */
 class DeviceTtlockMetadata
 {
     public static function from_json(mixed $json): DeviceTtlockMetadata|null
@@ -2216,16 +3837,40 @@ class DeviceTtlockMetadata
     }
 
     public function __construct(
+        /**
+         * Feature value for a TTLock device.
+         */
         public string|null $feature_value,
+        /**
+         * Features for a TTLock device.
+         */
         public DeviceFeatures|null $features,
+        /**
+         * Indicates whether a TTLock device has a gateway.
+         */
         public bool|null $has_gateway,
+        /**
+         * Lock alias for a TTLock device.
+         */
         public string|null $lock_alias,
+        /**
+         * Lock ID for a TTLock device.
+         */
         public float|null $lock_id,
+        /**
+         * Lock-side timezone offset in milliseconds east of UTC, as configured in the TTLock app. Source of truth for the lock's wall-clock interpretation of access code start/end times — a misconfigured value here is the typical cause of customer "codes offset by N hours" reports. Diagnostic only; Seam does not convert times based on this value.
+         */
         public float|null $timezone_raw_offset_ms,
+        /**
+         * Wireless keypads for a TTLock device.
+         */
         public array $wireless_keypads,
     ) {}
 }
 
+/**
+ * Metadata for a 2N device.
+ */
 class DeviceTwoNMetadata
 {
     public static function from_json(mixed $json): DeviceTwoNMetadata|null
@@ -2240,11 +3885,20 @@ class DeviceTwoNMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a 2N device.
+         */
         public float|null $device_id,
+        /**
+         * Device name for a 2N device.
+         */
         public string|null $device_name,
     ) {}
 }
 
+/**
+ * Metadata for an Ultraloq device.
+ */
 class DeviceUltraloqMetadata
 {
     public static function from_json(mixed $json): DeviceUltraloqMetadata|null
@@ -2261,13 +3915,28 @@ class DeviceUltraloqMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for an Ultraloq device.
+         */
         public string|null $device_id,
+        /**
+         * Device name for an Ultraloq device.
+         */
         public string|null $device_name,
+        /**
+         * Device type for an Ultraloq device.
+         */
         public string|null $device_type,
+        /**
+         * IANA timezone for the Ultraloq device.
+         */
         public string|null $time_zone,
     ) {}
 }
 
+/**
+ * Metadata for an ASSA ABLOY Visionline system.
+ */
 class DeviceVisionlineMetadata
 {
     public static function from_json(mixed $json): DeviceVisionlineMetadata|null
@@ -2278,9 +3947,17 @@ class DeviceVisionlineMetadata
         return new self(encoder_id: $json->encoder_id ?? null);
     }
 
-    public function __construct(public string|null $encoder_id) {}
+    public function __construct(
+        /**
+         * Encoder ID for an ASSA ABLOY Visionline system.
+         */
+        public string|null $encoder_id,
+    ) {}
 }
 
+/**
+ * Array of warnings associated with the device. Each warning object within the array contains two fields: `warning_code` and `message`. `warning_code` is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+ */
 class DeviceWarnings
 {
     public static function from_json(mixed $json): DeviceWarnings|null
@@ -2299,14 +3976,32 @@ class DeviceWarnings
     }
 
     public function __construct(
+        /**
+         * Number of active access codes on the device when the warning was set.
+         */
         public int|null $active_access_code_count,
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Maximum number of active access codes supported by the device.
+         */
         public int|null $max_active_access_code_count,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }
 
+/**
+ * Wireless keypads for a TTLock device.
+ */
 class DeviceWirelessKeypads
 {
     public static function from_json(mixed $json): DeviceWirelessKeypads|null
@@ -2321,11 +4016,20 @@ class DeviceWirelessKeypads
     }
 
     public function __construct(
+        /**
+         * ID for a wireless keypad for a TTLock device.
+         */
         public float|null $wireless_keypad_id,
+        /**
+         * Name for a wireless keypad for a TTLock device.
+         */
         public string|null $wireless_keypad_name,
     ) {}
 }
 
+/**
+ * Metadata for a Wyze device.
+ */
 class DeviceWyzeMetadata
 {
     public static function from_json(mixed $json): DeviceWyzeMetadata|null
@@ -2346,13 +4050,37 @@ class DeviceWyzeMetadata
     }
 
     public function __construct(
+        /**
+         * Device ID for a Wyze device.
+         */
         public string|null $device_id,
+        /**
+         * Device information model for a Wyze device.
+         */
         public string|null $device_info_model,
+        /**
+         * Device name for a Wyze device.
+         */
         public string|null $device_name,
+        /**
+         * Keypad UUID for a Wyze device.
+         */
         public string|null $keypad_uuid,
+        /**
+         * Locker status (hardlock) for a Wyze device.
+         */
         public float|null $locker_status_hardlock,
+        /**
+         * Product model for a Wyze device.
+         */
         public string|null $product_model,
+        /**
+         * Product name for a Wyze device.
+         */
         public string|null $product_name,
+        /**
+         * Product type for a Wyze device.
+         */
         public string|null $product_type,
     ) {}
 }

--- a/src/Resources/DeviceProvider.php
+++ b/src/Resources/DeviceProvider.php
@@ -48,29 +48,101 @@ class DeviceProvider
     }
 
     public function __construct(
+        /**
+         * Indicates whether the lock supports configuring automatic locking.
+         */
         public bool|null $can_configure_auto_lock,
+        /**
+         * Indicates whether the thermostat supports cooling.
+         */
         public bool|null $can_hvac_cool,
+        /**
+         * Indicates whether the thermostat supports heating.
+         */
         public bool|null $can_hvac_heat,
+        /**
+         * Indicates whether the thermostat supports simultaneous heating and cooling.
+         */
         public bool|null $can_hvac_heat_cool,
+        /**
+         * Indicates whether the device supports programming offline access codes.
+         */
         public bool|null $can_program_offline_access_codes,
+        /**
+         * Indicates whether the device supports programming online access codes.
+         */
         public bool|null $can_program_online_access_codes,
+        /**
+         * Indicates whether the thermostat supports different climate programs for each day of the week.
+         */
         public bool|null $can_program_thermostat_programs_as_different_each_day,
+        /**
+         * Indicates whether the thermostat supports a single climate program applied to every day.
+         */
         public bool|null $can_program_thermostat_programs_as_same_each_day,
+        /**
+         * Indicates whether the thermostat supports weekday/weekend climate programs.
+         */
         public bool|null $can_program_thermostat_programs_as_weekday_weekend,
+        /**
+         * Indicates whether the device supports remote locking.
+         */
         public bool|null $can_remotely_lock,
+        /**
+         * Indicates whether the device supports remote unlocking.
+         */
         public bool|null $can_remotely_unlock,
+        /**
+         * Indicates whether the thermostat supports running climate programs.
+         */
         public bool|null $can_run_thermostat_programs,
+        /**
+         * Indicates whether the device supports simulating connection in a sandbox.
+         */
         public bool|null $can_simulate_connection,
+        /**
+         * Indicates whether the device supports simulating disconnection in a sandbox.
+         */
         public bool|null $can_simulate_disconnection,
+        /**
+         * Indicates whether the hub supports simulating connection in a sandbox.
+         */
         public bool|null $can_simulate_hub_connection,
+        /**
+         * Indicates whether the hub supports simulating disconnection in a sandbox.
+         */
         public bool|null $can_simulate_hub_disconnection,
+        /**
+         * Indicates whether the device supports simulating a paid subscription in a sandbox.
+         */
         public bool|null $can_simulate_paid_subscription,
+        /**
+         * Indicates whether the device supports simulating removal in a sandbox.
+         */
         public bool|null $can_simulate_removal,
+        /**
+         * Indicates whether the thermostat can be turned off.
+         */
         public bool|null $can_turn_off_hvac,
+        /**
+         * Indicates whether the lock supports unlocking with an access code.
+         */
         public bool|null $can_unlock_with_code,
+        /**
+         * Name of the device provider.
+         */
         public string|null $device_provider_name,
+        /**
+         * Display name for the device provider.
+         */
         public string|null $display_name,
+        /**
+         * Image URL for the device provider.
+         */
         public string|null $image_url,
+        /**
+         * List of provider categories to which the device provider belongs, such as `stable`, `consumer_smartlocks`, `thermostats`, and so on.
+         */
         public array|null $provider_categories,
     ) {}
 }

--- a/src/Resources/Event.php
+++ b/src/Resources/Event.php
@@ -143,100 +143,375 @@ class Event
     }
 
     public function __construct(
+        /**
+         * Errors associated with the access code.
+         */
         public array $access_code_errors,
+        /**
+         * ID of the affected access code.
+         */
         public string|null $access_code_id,
+        /**
+         * Whether the access code is managed by Seam (true) or unmanaged (false). Only present when access_code_id is set.
+         */
         public bool|null $access_code_is_managed,
+        /**
+         * Warnings associated with the access code.
+         */
         public array $access_code_warnings,
+        /**
+         * ID of the affected Access Grant.
+         */
         public string|null $access_grant_id,
+        /**
+         * IDs of the access grants associated with this access method.
+         */
         public array|null $access_grant_ids,
+        /**
+         * Key of the affected Access Grant (if present).
+         */
         public string|null $access_grant_key,
+        /**
+         * Keys of the access grants associated with this access method (if present).
+         */
         public array|null $access_grant_keys,
+        /**
+         * ID of the affected access method.
+         */
         public string|null $access_method_id,
+        /**
+         * ID of the affected access group.
+         */
         public string|null $acs_access_group_id,
+        /**
+         * ID of the affected credential.
+         */
         public string|null $acs_credential_id,
+        /**
+         * ID of the affected encoder.
+         */
         public string|null $acs_encoder_id,
+        /**
+         * ID of the affected [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+         */
         public string|null $acs_entrance_id,
+        /**
+         * IDs of all ACS entrances currently attached to the space.
+         */
         public array|null $acs_entrance_ids,
+        /**
+         * Errors associated with the access control system.
+         */
         public array $acs_system_errors,
+        /**
+         * ID of the access system.
+         */
         public string|null $acs_system_id,
+        /**
+         * Warnings associated with the access control system.
+         */
         public array $acs_system_warnings,
+        /**
+         * ID of the affected access system user.
+         */
         public string|null $acs_user_id,
+        /**
+         * ID of the affected action attempt.
+         */
         public string|null $action_attempt_id,
+        /**
+         * Type of the action.
+         */
         public string|null $action_type,
+        /**
+         * The reason the camera was activated.
+         */
         public string|null $activation_reason,
+        /**
+         * ID of the backup access code that was pulled from the pool.
+         */
         public string|null $backup_access_code_id,
+        /**
+         * Number in the range 0 to 1.0 indicating the amount of battery in the affected device, as reported by the device.
+         */
         public float|null $battery_level,
+        /**
+         * Battery status of the affected device, calculated from the numeric `battery_level` value.
+         */
         public string|null $battery_status,
+        /**
+         * Human-readable reason for the change (e.g. `ongoing code auto-renewed`).
+         */
         public string|null $change_reason,
+        /**
+         * List of properties that changed on the access code.
+         */
         public array $changed_properties,
+        /**
+         * ID of the affected client session.
+         */
         public string|null $client_session_id,
+        /**
+         * Key of the climate preset that was activated.
+         */
         public string|null $climate_preset_key,
+        /**
+         * Code for the affected access code.
+         */
         public string|null $code,
+        /**
+         * ID of the Connect Webview associated with the event.
+         */
         public string|null $connect_webview_id,
+        /**
+         * Custom metadata of the connected account, present when connected_account_id is provided.
+         */
         public mixed $connected_account_custom_metadata,
+        /**
+         * Errors associated with the connected account.
+         */
         public array $connected_account_errors,
+        /**
+         * ID of the connected account associated with the affected access code.
+         */
         public string|null $connected_account_id,
+        /**
+         * undocumented: Unreleased.
+         */
         public string|null $connected_account_type,
+        /**
+         * Warnings associated with the connected account.
+         */
         public array $connected_account_warnings,
+        /**
+         * Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $cooling_set_point_celsius,
+        /**
+         * Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $cooling_set_point_fahrenheit,
+        /**
+         * Date and time at which the event was created.
+         */
         public string|null $created_at,
+        /**
+         * The customer key associated with this connected account, if any.
+         */
         public string|null $customer_key,
+        /**
+         * Human-readable description of the change and its source.
+         */
         public string|null $description,
+        /**
+         * Desired temperature, in °C, defined by the affected thermostat's cooling or heating set point.
+         */
         public float|null $desired_temperature_celsius,
+        /**
+         * Desired temperature, in °F, defined by the affected thermostat's cooling or heating set point.
+         */
         public float|null $desired_temperature_fahrenheit,
+        /**
+         * Custom metadata of the device, present when device_id is provided.
+         */
         public mixed $device_custom_metadata,
+        /**
+         * Errors associated with the device.
+         */
         public array $device_errors,
+        /**
+         * ID of the device associated with the affected access code.
+         */
         public string|null $device_id,
+        /**
+         * IDs of all devices currently attached to the space.
+         */
         public array|null $device_ids,
+        /**
+         * Name of the deleted device, captured at deletion time. The device record no longer exists when this event fires, so the name is preserved here. Null when the device had no resolvable name.
+         */
         public string|null $device_name,
+        /**
+         * Warnings associated with the device.
+         */
         public array $device_warnings,
+        /**
+         * The new end time for the access grant.
+         */
         public string|null $ends_at,
+        /**
+         * Error code associated with the disconnection event, if any.
+         */
         public string|null $error_code,
+        /**
+         * Description of why the access methods could not be created.
+         */
         public string|null $error_message,
+        /**
+         * Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+         */
         public string|null $event_description,
+        /**
+         * ID of the event.
+         */
         public string|null $event_id,
         public string|null $event_type,
+        /**
+         * Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+         */
         public string|null $fan_mode_setting,
+        /**
+         * Previous access code name configuration.
+         */
         public EventFrom|null $from,
+        /**
+         * Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $heating_set_point_celsius,
+        /**
+         * Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+         */
         public float|null $heating_set_point_fahrenheit,
+        /**
+         * Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+         */
         public string|null $hvac_mode_setting,
+        /**
+         * URL to a thumbnail image captured at the time of activation.
+         */
         public string|null $image_url,
+        /**
+         * Indicates whether the code is a backup code (only present when mode is 'code' and a backup code was used).
+         */
         public bool|null $is_backup_code,
+        /**
+         * Indicates whether the climate preset that was activated is the fallback climate preset for the thermostat.
+         */
         public bool|null $is_fallback_climate_preset,
+        /**
+         * Whether the lock action was performed over Bluetooth by a remote client (such as the provider's mobile app), rather than a direct physical interaction or a Seam-initiated remote action.
+         */
         public bool|null $is_via_bluetooth,
+        /**
+         * Whether the lock action was performed by an NFC credential tap (such as an Apple Home Key or an NFC key fob) presented to the lock, rather than a direct physical interaction or a Seam-initiated remote action.
+         */
         public bool|null $is_via_nfc,
+        /**
+         * Lower temperature limit, in °C, defined by the set threshold.
+         */
         public float|null $lower_limit_celsius,
+        /**
+         * Lower temperature limit, in °F, defined by the set threshold.
+         */
         public float|null $lower_limit_fahrenheit,
+        /**
+         * Method by which the lock was locked. `keycode`: an access code was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or button press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by an auto-relock timer. `unknown`: could not be determined.
+         */
         public string|null $method,
+        /**
+         * Metadata from Minut.
+         */
         public mixed $minut_metadata,
+        /**
+         * IDs of the devices that did not receive a requested access method. Use these to identify which specific devices failed without having to fetch the Access Grant.
+         */
         public array|null $missing_device_ids,
+        /**
+         * Sub-type of motion detected, if available.
+         */
         public string|null $motion_sub_type,
+        /**
+         * Detected noise level in decibels.
+         */
         public float|null $noise_level_decibels,
+        /**
+         * Detected noise level in Noiseaware Noise Risk Score (NRS).
+         */
         public float|null $noise_level_nrs,
+        /**
+         * ID of the noise threshold that was triggered.
+         */
         public string|null $noise_threshold_id,
+        /**
+         * Name of the noise threshold that was triggered.
+         */
         public string|null $noise_threshold_name,
+        /**
+         * Metadata from Noiseaware.
+         */
         public mixed $noiseaware_metadata,
+        /**
+         * Date and time at which the event occurred.
+         */
         public string|null $occurred_at,
+        /**
+         * Why access was denied, when the provider reports a determinable cause. Omitted when unknown.
+         */
         public EventReason|null $reason,
+        /**
+         * Array of mutations requested on the access code, each containing the mutation type and from/to values.
+         */
         public array $requested_mutations,
+        /**
+         * ID of the affected space.
+         */
         public string|null $space_id,
+        /**
+         * Unique key for the space within the workspace.
+         */
         public string|null $space_key,
+        /**
+         * The new start time for the access grant.
+         */
         public string|null $starts_at,
+        /**
+         * Status of the action.
+         */
         public string|null $status,
+        /**
+         * Temperature, in °C, reported by the affected thermostat.
+         */
         public float|null $temperature_celsius,
+        /**
+         * Temperature, in °F, reported by the affected thermostat.
+         */
         public float|null $temperature_fahrenheit,
+        /**
+         * ID of the thermostat schedule that prompted the affected climate preset to be activated.
+         */
         public string|null $thermostat_schedule_id,
+        /**
+         * New access code name configuration.
+         */
         public EventTo|null $to,
+        /**
+         * Upper temperature limit, in °C, defined by the set threshold.
+         */
         public float|null $upper_limit_celsius,
+        /**
+         * Upper temperature limit, in °F, defined by the set threshold.
+         */
         public float|null $upper_limit_fahrenheit,
+        /**
+         * undocumented: Unreleased.
+         *       ---
+         *       ID of the user identity associated with the lock event.
+         */
         public string|null $user_identity_id,
+        /**
+         * URL to a short video clip captured at the time of activation.
+         */
         public string|null $video_url,
+        /**
+         * ID of the workspace associated with the event.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Errors associated with the access code.
+ */
 class EventAccessCodeErrors
 {
     public static function from_json(mixed $json): EventAccessCodeErrors|null
@@ -252,12 +527,24 @@ class EventAccessCodeErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Warnings associated with the access code.
+ */
 class EventAccessCodeWarnings
 {
     public static function from_json(mixed $json): EventAccessCodeWarnings|null
@@ -273,12 +560,24 @@ class EventAccessCodeWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }
 
+/**
+ * Errors associated with the access control system.
+ */
 class EventAcsSystemErrors
 {
     public static function from_json(mixed $json): EventAcsSystemErrors|null
@@ -294,12 +593,24 @@ class EventAcsSystemErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Warnings associated with the access control system.
+ */
 class EventAcsSystemWarnings
 {
     public static function from_json(mixed $json): EventAcsSystemWarnings|null
@@ -315,12 +626,24 @@ class EventAcsSystemWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }
 
+/**
+ * List of properties that changed on the access code.
+ */
 class EventChangedProperties
 {
     public static function from_json(mixed $json): EventChangedProperties|null
@@ -336,12 +659,24 @@ class EventChangedProperties
     }
 
     public function __construct(
+        /**
+         * Previous value of the property, or null if not set.
+         */
         public string|null $from,
+        /**
+         * Name of the property that changed (e.g. `code`).
+         */
         public string|null $property,
+        /**
+         * New value of the property, or null if cleared.
+         */
         public string|null $to,
     ) {}
 }
 
+/**
+ * Errors associated with the connected account.
+ */
 class EventConnectedAccountErrors
 {
     public static function from_json(
@@ -358,12 +693,24 @@ class EventConnectedAccountErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Warnings associated with the connected account.
+ */
 class EventConnectedAccountWarnings
 {
     public static function from_json(
@@ -380,12 +727,24 @@ class EventConnectedAccountWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }
 
+/**
+ * Errors associated with the device.
+ */
 class EventDeviceErrors
 {
     public static function from_json(mixed $json): EventDeviceErrors|null
@@ -401,12 +760,24 @@ class EventDeviceErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Warnings associated with the device.
+ */
 class EventDeviceWarnings
 {
     public static function from_json(mixed $json): EventDeviceWarnings|null
@@ -422,12 +793,24 @@ class EventDeviceWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }
 
+/**
+ * Previous access code name configuration.
+ */
 class EventFrom
 {
     public static function from_json(mixed $json): EventFrom|null
@@ -444,13 +827,28 @@ class EventFrom
     }
 
     public function __construct(
+        /**
+         * Previous pin code.
+         */
         public string|null $code,
+        /**
+         * Previous end time.
+         */
         public string|null $ends_at,
+        /**
+         * Previous name of the access code.
+         */
         public string|null $name,
+        /**
+         * Previous start time.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Why access was denied, when the provider reports a determinable cause. Omitted when unknown.
+ */
 class EventReason
 {
     public static function from_json(mixed $json): EventReason|null
@@ -465,11 +863,20 @@ class EventReason
     }
 
     public function __construct(
+        /**
+         * Human-readable explanation of why access was denied.
+         */
         public string|null $message,
+        /**
+         * Normalized reason a lock denied access. Provider-agnostic; not all providers report every value.
+         */
         public string|null $reason_code,
     ) {}
 }
 
+/**
+ * Array of mutations requested on the access code, each containing the mutation type and from/to values.
+ */
 class EventRequestedMutations
 {
     public static function from_json(mixed $json): EventRequestedMutations|null
@@ -485,12 +892,24 @@ class EventRequestedMutations
     }
 
     public function __construct(
+        /**
+         * Previous property values before the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
+         */
         public mixed $from,
+        /**
+         * Code identifying the type of mutation requested, such as `updating_name`, `updating_code`, `updating_time_frame`, or `deleting`.
+         */
         public string|null $mutation_code,
+        /**
+         * New property values after the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
+         */
         public mixed $to,
     ) {}
 }
 
+/**
+ * New access code name configuration.
+ */
 class EventTo
 {
     public static function from_json(mixed $json): EventTo|null
@@ -507,9 +926,21 @@ class EventTo
     }
 
     public function __construct(
+        /**
+         * New pin code.
+         */
         public string|null $code,
+        /**
+         * New end time.
+         */
         public string|null $ends_at,
+        /**
+         * New name of the access code.
+         */
         public string|null $name,
+        /**
+         * New start time.
+         */
         public string|null $starts_at,
     ) {}
 }

--- a/src/Resources/InstantKey.php
+++ b/src/Resources/InstantKey.php
@@ -2,6 +2,11 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a Seam Instant Key. For issuing Bluetooth mobile keys, Instant Keys are the fastest way to share access. With a single API call, you can create a mobile key and send it through text or email or embed it in your own app.
+ *
+ * There’s no app to install, nor account to create. Your user just taps a link and gets a lightweight, native-feeling experience using iOS App Clip or Instant Apps on Android. Further, Instant Keys work offline, so even in areas with poor cellular or Wi-Fi, like elevator banks or concrete-walled hallways, the Instant Keys still work.
+ */
 class InstantKey
 {
     public static function from_json(mixed $json): InstantKey|null
@@ -25,18 +30,48 @@ class InstantKey
     }
 
     public function __construct(
+        /**
+         * ID of the client session associated with the Instant Key.
+         */
         public string|null $client_session_id,
+        /**
+         * Date and time at which the Instant Key was created.
+         */
         public string|null $created_at,
+        /**
+         * Customization applied to the Instant Key UI.
+         */
         public InstantKeyCustomization|null $customization,
+        /**
+         * ID of the customization profile associated with the Instant Key.
+         */
         public string|null $customization_profile_id,
+        /**
+         * Date and time at which the Instant Key expires.
+         */
         public string|null $expires_at,
+        /**
+         * ID of the Instant Key.
+         */
         public string|null $instant_key_id,
+        /**
+         * Shareable URL for the Instant Key. Use the URL to deliver the Instant Key to your user through a link in a text message or email or by embedding it in your web app.
+         */
         public string|null $instant_key_url,
+        /**
+         * ID of the user identity associated with the Instant Key.
+         */
         public string|null $user_identity_id,
+        /**
+         * ID of the workspace that contains the Instant Key.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Customization applied to the Instant Key UI.
+ */
 class InstantKeyCustomization
 {
     public static function from_json(mixed $json): InstantKeyCustomization|null
@@ -52,8 +87,17 @@ class InstantKeyCustomization
     }
 
     public function __construct(
+        /**
+         * URL of the logo displayed on the Instant Key.
+         */
         public string|null $logo_url,
+        /**
+         * Primary color used in the Instant Key UI.
+         */
         public string|null $primary_color,
+        /**
+         * Secondary color used in the Instant Key UI.
+         */
         public string|null $secondary_color,
     ) {}
 }

--- a/src/Resources/NoiseThreshold.php
+++ b/src/Resources/NoiseThreshold.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+ */
 class NoiseThreshold
 {
     public static function from_json(mixed $json): NoiseThreshold|null
@@ -21,12 +24,33 @@ class NoiseThreshold
     }
 
     public function __construct(
+        /**
+         * Unique identifier for the device that contains the noise threshold.
+         */
         public string|null $device_id,
+        /**
+         * Time at which the noise threshold should become inactive daily.
+         */
         public string|null $ends_daily_at,
+        /**
+         * Name of the noise threshold.
+         */
         public string|null $name,
+        /**
+         * Noise level in decibels for the noise threshold.
+         */
         public float|null $noise_threshold_decibels,
+        /**
+         * Unique identifier for the noise threshold.
+         */
         public string|null $noise_threshold_id,
+        /**
+         * Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).
+         */
         public float|null $noise_threshold_nrs,
+        /**
+         * Time at which the noise threshold should become active daily.
+         */
         public string|null $starts_daily_at,
     ) {}
 }

--- a/src/Resources/Phone.php
+++ b/src/Resources/Phone.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an app user's mobile phone.
+ */
 class Phone
 {
     public static function from_json(mixed $json): Phone|null
@@ -32,19 +35,52 @@ class Phone
     }
 
     public function __construct(
+        /**
+         * Date and time at which the phone was created.
+         */
         public string|null $created_at,
+        /**
+         * Optional [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for the phone.
+         */
         public mixed $custom_metadata,
+        /**
+         * ID of the phone.
+         */
         public string|null $device_id,
+        /**
+         * Type of the phone device, such as `ios_phone` or `android_phone`.
+         */
         public string|null $device_type,
+        /**
+         * Display name of the phone. Defaults to `nickname` (if it is set) or `properties.appearance.name`, otherwise. Enables administrators and users to identify the phone easily, especially when there are numerous phones.
+         */
         public string|null $display_name,
+        /**
+         * Errors associated with the phone.
+         */
         public array $errors,
+        /**
+         * Optional nickname to describe the phone, settable through Seam.
+         */
         public string|null $nickname,
+        /**
+         * Properties of the phone.
+         */
         public PhoneProperties|null $properties,
+        /**
+         * Warnings associated with the phone.
+         */
         public array $warnings,
+        /**
+         * ID of the workspace that contains the phone.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * ASSA ABLOY Credential Service metadata for the phone.
+ */
 class PhoneAssaAbloyCredentialServiceMetadata
 {
     public static function from_json(
@@ -63,11 +99,20 @@ class PhoneAssaAbloyCredentialServiceMetadata
     }
 
     public function __construct(
+        /**
+         * Endpoints associated with the phone.
+         */
         public array $endpoints,
+        /**
+         * Indicates whether the credential service has active endpoints associated with the phone.
+         */
         public bool|null $has_active_endpoint,
     ) {}
 }
 
+/**
+ * Endpoints associated with the phone.
+ */
 class PhoneEndpoints
 {
     public static function from_json(mixed $json): PhoneEndpoints|null
@@ -82,11 +127,20 @@ class PhoneEndpoints
     }
 
     public function __construct(
+        /**
+         * ID of the associated endpoint.
+         */
         public string|null $endpoint_id,
+        /**
+         * Indicated whether the endpoint is active.
+         */
         public bool|null $is_active,
     ) {}
 }
 
+/**
+ * Errors associated with the phone.
+ */
 class PhoneErrors
 {
     public static function from_json(mixed $json): PhoneErrors|null
@@ -102,12 +156,24 @@ class PhoneErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Properties of the phone.
+ */
 class PhoneProperties
 {
     public static function from_json(mixed $json): PhoneProperties|null
@@ -134,11 +200,20 @@ class PhoneProperties
     }
 
     public function __construct(
+        /**
+         * ASSA ABLOY Credential Service metadata for the phone.
+         */
         public PhoneAssaAbloyCredentialServiceMetadata|null $assa_abloy_credential_service_metadata,
+        /**
+         * Salto Space credential service metadata for the phone.
+         */
         public PhoneSaltoSpaceCredentialServiceMetadata|null $salto_space_credential_service_metadata,
     ) {}
 }
 
+/**
+ * Salto Space credential service metadata for the phone.
+ */
 class PhoneSaltoSpaceCredentialServiceMetadata
 {
     public static function from_json(
@@ -150,9 +225,17 @@ class PhoneSaltoSpaceCredentialServiceMetadata
         return new self(has_active_phone: $json->has_active_phone ?? null);
     }
 
-    public function __construct(public bool|null $has_active_phone) {}
+    public function __construct(
+        /**
+         * Indicates whether the credential service has an active associated phone.
+         */
+        public bool|null $has_active_phone,
+    ) {}
 }
 
+/**
+ * Warnings associated with the phone.
+ */
 class PhoneWarnings
 {
     public static function from_json(mixed $json): PhoneWarnings|null
@@ -168,8 +251,17 @@ class PhoneWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/Space.php
+++ b/src/Resources/Space.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a space that is a logical grouping of devices and entrances. You can assign access to an entire space, thereby making granting access more efficient.
+ */
 class Space
 {
     public static function from_json(mixed $json): Space|null
@@ -29,20 +32,56 @@ class Space
     }
 
     public function __construct(
+        /**
+         * Number of entrances in the space.
+         */
         public float|null $acs_entrance_count,
+        /**
+         * Date and time at which the space was created.
+         */
         public string|null $created_at,
+        /**
+         * Reservation/stay-related defaults for the space. Also carries the provider/PMS-supplied name under a `<connector_type>_name` key (e.g. `guesty_name`), which Seam preserves when you rename the space (read-only — managed by Seam).
+         */
         public SpaceCustomerData|null $customer_data,
+        /**
+         * Customer key associated with the space.
+         */
         public string|null $customer_key,
+        /**
+         * Number of devices in the space.
+         */
         public float|null $device_count,
+        /**
+         * Display name for the space.
+         */
         public string|null $display_name,
+        /**
+         * Geographic coordinates (latitude and longitude) of the space.
+         */
         public SpaceGeolocation|null $geolocation,
+        /**
+         * Name of the space.
+         */
         public string|null $name,
+        /**
+         * ID of the space.
+         */
         public string|null $space_id,
+        /**
+         * Unique key for the space within the workspace.
+         */
         public string|null $space_key,
+        /**
+         * ID of the workspace associated with the space.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Reservation/stay-related defaults for the space. Also carries the provider/PMS-supplied name under a `<connector_type>_name` key (e.g. `guesty_name`), which Seam preserves when you rename the space (read-only — managed by Seam).
+ */
 class SpaceCustomerData
 {
     public static function from_json(mixed $json): SpaceCustomerData|null
@@ -59,13 +98,28 @@ class SpaceCustomerData
     }
 
     public function __construct(
+        /**
+         * Postal address for the space.
+         */
         public string|null $address,
+        /**
+         * Default check-in time for reservations at the space, as HH:mm or HH:mm:ss.
+         */
         public string|null $default_checkin_time,
+        /**
+         * Default check-out time for reservations at the space, as HH:mm or HH:mm:ss.
+         */
         public string|null $default_checkout_time,
+        /**
+         * IANA time zone for the space, e.g. America/Los_Angeles.
+         */
         public string|null $time_zone,
     ) {}
 }
 
+/**
+ * Geographic coordinates (latitude and longitude) of the space.
+ */
 class SpaceGeolocation
 {
     public static function from_json(mixed $json): SpaceGeolocation|null
@@ -80,7 +134,13 @@ class SpaceGeolocation
     }
 
     public function __construct(
+        /**
+         * Latitude of the space, in decimal degrees.
+         */
         public float|null $latitude,
+        /**
+         * Longitude of the space, in decimal degrees.
+         */
         public float|null $longitude,
     ) {}
 }

--- a/src/Resources/ThermostatDailyProgram.php
+++ b/src/Resources/ThermostatDailyProgram.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a thermostat daily program, consisting of a set of periods, each of which has a starting time and the key that identifies the climate preset to apply at the starting time.
+ */
 class ThermostatDailyProgram
 {
     public static function from_json(mixed $json): ThermostatDailyProgram|null
@@ -24,15 +27,36 @@ class ThermostatDailyProgram
     }
 
     public function __construct(
+        /**
+         * Date and time at which the thermostat daily program was created.
+         */
         public string|null $created_at,
+        /**
+         * ID of the thermostat device on which the thermostat daily program is configured.
+         */
         public string|null $device_id,
+        /**
+         * User-friendly name to identify the thermostat daily program.
+         */
         public string|null $name,
+        /**
+         * Array of thermostat daily program periods.
+         */
         public array $periods,
+        /**
+         * ID of the thermostat daily program.
+         */
         public string|null $thermostat_daily_program_id,
+        /**
+         * ID of the workspace that contains the thermostat daily program.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Array of thermostat daily program periods.
+ */
 class ThermostatDailyProgramPeriods
 {
     public static function from_json(
@@ -48,7 +72,13 @@ class ThermostatDailyProgramPeriods
     }
 
     public function __construct(
+        /**
+         * Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.
+         */
         public string|null $climate_preset_key,
+        /**
+         * Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $starts_at_time,
     ) {}
 }

--- a/src/Resources/ThermostatSchedule.php
+++ b/src/Resources/ThermostatSchedule.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) that activates a configured [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) on a [thermostat](https://docs.seam.co/capability-guides/thermostats) at a specified starting time and deactivates the climate preset at a specified ending time.
+ */
 class ThermostatSchedule
 {
     public static function from_json(mixed $json): ThermostatSchedule|null
@@ -29,20 +32,56 @@ class ThermostatSchedule
     }
 
     public function __construct(
+        /**
+         * Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         */
         public string|null $climate_preset_key,
+        /**
+         * Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.
+         */
         public string|null $created_at,
+        /**
+         * ID of the desired [thermostat](https://docs.seam.co/capability-guides/thermostats) device.
+         */
         public string|null $device_id,
+        /**
+         * Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $ends_at,
+        /**
+         * Errors associated with the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         */
         public array $errors,
+        /**
+         * Indicates whether a person at the thermostat can change the thermostat's settings after the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.
+         */
         public bool|null $is_override_allowed,
+        /**
+         * Number of minutes for which a person at the thermostat can change the thermostat's settings after the activation of the scheduled [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+         */
         public int|null $max_override_period_minutes,
+        /**
+         * User-friendly name to identify the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         */
         public string|null $name,
+        /**
+         * Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+         */
         public string|null $starts_at,
+        /**
+         * ID of the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+         */
         public string|null $thermostat_schedule_id,
+        /**
+         * ID of the workspace that contains the thermostat schedule.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Errors associated with the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+ */
 class ThermostatScheduleErrors
 {
     public static function from_json(mixed $json): ThermostatScheduleErrors|null
@@ -58,8 +97,17 @@ class ThermostatScheduleErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }

--- a/src/Resources/UnmanagedAccessCode.php
+++ b/src/Resources/UnmanagedAccessCode.php
@@ -2,6 +2,19 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an [unmanaged smart lock access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+ *
+ * An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly.
+ *
+ * When you create an access code on a device in Seam, it is created as a managed access code. Access codes that exist on a device that were not created through Seam are considered unmanaged codes. We strictly limit the operations that can be performed on unmanaged codes.
+ *
+ * Prior to using Seam to manage your devices, you may have used another lock management system to manage the access codes on your devices. Where possible, we help you keep any existing access codes on devices and transition those codes to ones managed by your Seam workspace.
+ *
+ * Not all providers support unmanaged access codes. The following providers do not support unmanaged access codes:
+ *
+ * - [Kwikset](https://docs.seam.co/device-and-system-integration-guides/kwikset-locks)
+ */
 class UnmanagedAccessCode
 {
     public static function from_json(mixed $json): UnmanagedAccessCode|null
@@ -41,25 +54,76 @@ class UnmanagedAccessCode
     }
 
     public function __construct(
+        /**
+         * Unique identifier for the access code.
+         */
         public string|null $access_code_id,
+        /**
+         * Indicates that Seam cannot convert this unmanaged access code to a managed access code. Some providers do not support management of unmanaged access codes through API integrations.
+         */
         public bool|null $cannot_be_managed,
+        /**
+         * Indicates that Seam cannot delete this unmanaged access code through the provider. If this access code needs to be deleted, it will only be possible from the manufacturer app.
+         */
         public bool|null $cannot_delete_unmanaged_access_code,
+        /**
+         * Code used for access. Typically, a numeric or alphanumeric string.
+         */
         public string|null $code,
+        /**
+         * Date and time at which the access code was created.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier for the device associated with the access code.
+         */
         public string|null $device_id,
+        /**
+         * Metadata for a dormakaba Oracode unmanaged access code. Only present for unmanaged access codes from dormakaba Oracode devices.
+         */
         public UnmanagedAccessCodeDormakabaOracodeMetadata|null $dormakaba_oracode_metadata,
+        /**
+         * Date and time after which the time-bound access code becomes inactive.
+         */
         public string|null $ends_at,
+        /**
+         * Errors associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+         */
         public array $errors,
+        /**
+         * Indicates that Seam does not manage the access code.
+         */
         public bool|null $is_managed,
+        /**
+         * Name of the access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes. Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider's app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`. To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider's app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints. To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+         */
         public string|null $name,
+        /**
+         * Date and time at which the time-bound access code becomes active.
+         */
         public string|null $starts_at,
+        /**
+         * Current status of the access code within the operational lifecycle. `set` indicates that the code is active and operational. `unset` indicates that the code exists on the provider but is not usable on the device.
+         */
         public string|null $status,
+        /**
+         * Type of the access code. `ongoing` access codes are active continuously until deactivated manually. `time_bound` access codes have a specific duration.
+         */
         public string|null $type,
+        /**
+         * Warnings associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+         */
         public array $warnings,
+        /**
+         * Unique identifier for the Seam workspace associated with the access code.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Metadata for a dormakaba Oracode unmanaged access code. Only present for unmanaged access codes from dormakaba Oracode devices.
+ */
 class UnmanagedAccessCodeDormakabaOracodeMetadata
 {
     public static function from_json(
@@ -81,17 +145,44 @@ class UnmanagedAccessCodeDormakabaOracodeMetadata
     }
 
     public function __construct(
+        /**
+         * Indicates whether the stay can be cancelled via the Dormakaba Oracode API.
+         */
         public bool|null $is_cancellable,
+        /**
+         * Indicates whether early check-in is available for this stay.
+         */
         public bool|null $is_early_checkin_able,
+        /**
+         * Indicates whether the stay can be extended via the Dormakaba Oracode API.
+         */
         public bool|null $is_extendable,
+        /**
+         * Indicates whether the access code can be overridden. When false, the maximum number of overrides has been reached.
+         */
         public bool|null $is_overridable,
+        /**
+         * Dormakaba Oracode site name associated with this access code.
+         */
         public string|null $site_name,
+        /**
+         * Dormakaba Oracode stay ID associated with this access code.
+         */
         public float|null $stay_id,
+        /**
+         * Dormakaba Oracode user level ID associated with this access code.
+         */
         public string|null $user_level_id,
+        /**
+         * Dormakaba Oracode user level name associated with this access code.
+         */
         public string|null $user_level_name,
     ) {}
 }
 
+/**
+ * Errors associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+ */
 class UnmanagedAccessCodeErrors
 {
     public static function from_json(
@@ -120,20 +211,56 @@ class UnmanagedAccessCodeErrors
     }
 
     public function __construct(
+        /**
+         * Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
+         */
         public string|null $change_type,
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Indicates that this is an access code error.
+         */
         public bool|null $is_access_code_error,
+        /**
+         * Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+         */
         public bool|null $is_bridge_error,
+        /**
+         * Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+         */
         public bool|null $is_connected_account_error,
+        /**
+         * Indicates that the error is not a device error.
+         */
         public bool|null $is_device_error,
+        /**
+         * ID of the managed access code that conflicts with this managed access code, when Seam can identify it.
+         */
         public string|null $managed_access_code_id,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * List of fields that were changed externally, with their previous and new values.
+         */
         public array $modified_fields,
+        /**
+         * ID of the unmanaged access code that conflicts with this managed access code, when Seam can identify it.
+         */
         public string|null $unmanaged_access_code_id,
     ) {}
 }
 
+/**
+ * List of fields that were changed externally, with their previous and new values.
+ */
 class UnmanagedAccessCodeModifiedFields
 {
     public static function from_json(
@@ -150,12 +277,24 @@ class UnmanagedAccessCodeModifiedFields
     }
 
     public function __construct(
+        /**
+         * The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+         */
         public string|null $field,
+        /**
+         * The previous value of the field.
+         */
         public string|null $from,
+        /**
+         * The new value of the field.
+         */
         public string|null $to,
     ) {}
 }
 
+/**
+ * Warnings associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+ */
 class UnmanagedAccessCodeWarnings
 {
     public static function from_json(
@@ -177,10 +316,25 @@ class UnmanagedAccessCodeWarnings
     }
 
     public function __construct(
+        /**
+         * Indicates the type of external modification. `modified` means the code's PIN or schedule was changed. `removed` means the code was deleted from the device.
+         */
         public string|null $change_type,
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * List of fields that were changed externally, with their previous and new values.
+         */
         public array $modified_fields,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/UnmanagedAccessGrant.php
+++ b/src/Resources/UnmanagedAccessGrant.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an unmanaged Access Grant. Unmanaged Access Grants do not have client sessions, instant keys, customization profiles, or keys.
+ */
 class UnmanagedAccessGrant
 {
     public static function from_json(mixed $json): UnmanagedAccessGrant|null
@@ -44,25 +47,76 @@ class UnmanagedAccessGrant
     }
 
     public function __construct(
+        /**
+         * ID of the Access Grant.
+         */
         public string|null $access_grant_id,
+        /**
+         * IDs of the access methods created for the Access Grant.
+         */
         public array|null $access_method_ids,
+        /**
+         * Date and time at which the Access Grant was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name of the Access Grant.
+         */
         public string|null $display_name,
+        /**
+         * Date and time at which the Access Grant ends.
+         */
         public string|null $ends_at,
+        /**
+         * Errors associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+         */
         public array $errors,
+        /**
+         * @deprecated Use `space_ids`.
+         */
         public array|null $location_ids,
+        /**
+         * Name of the Access Grant. If not provided, the display name will be computed.
+         */
         public string|null $name,
+        /**
+         * List of pending mutations for the access grant. This shows updates that are in progress.
+         */
         public array $pending_mutations,
+        /**
+         * Access methods that the user requested for the Access Grant.
+         */
         public array $requested_access_methods,
+        /**
+         * Reservation key for the access grant.
+         */
         public string|null $reservation_key,
+        /**
+         * IDs of the spaces to which the Access Grant gives access.
+         */
         public array|null $space_ids,
+        /**
+         * Date and time at which the Access Grant starts.
+         */
         public string|null $starts_at,
+        /**
+         * ID of user identity to which the Access Grant gives access.
+         */
         public string|null $user_identity_id,
+        /**
+         * Warnings associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+         */
         public array $warnings,
+        /**
+         * ID of the Seam workspace associated with the Access Grant.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Errors associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+ */
 class UnmanagedAccessGrantErrors
 {
     public static function from_json(
@@ -80,13 +134,28 @@ class UnmanagedAccessGrantErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * IDs of the devices that did not receive an access code at grant creation. Use these to identify which specific devices failed when the message reports a partial failure.
+         */
         public array|null $missing_device_ids,
     ) {}
 }
 
+/**
+ * Devices whose access codes could not be revoked during reconciliation. Present when the provider does not support revoking an offline access code (e.g. Dormakaba oracode with exhausted override budget).
+ */
 class UnmanagedAccessGrantFailedDevices
 {
     public static function from_json(
@@ -103,12 +172,24 @@ class UnmanagedAccessGrantFailedDevices
     }
 
     public function __construct(
+        /**
+         * Device whose access code could not be revoked.
+         */
         public string|null $device_id,
+        /**
+         * Reason the access code could not be revoked (e.g. `offline_access_code_not_revocable`).
+         */
         public string|null $error_code,
+        /**
+         * Human-readable description of why revocation failed.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Previous location configuration.
+ */
 class UnmanagedAccessGrantFrom
 {
     public static function from_json(mixed $json): UnmanagedAccessGrantFrom|null
@@ -124,12 +205,24 @@ class UnmanagedAccessGrantFrom
     }
 
     public function __construct(
+        /**
+         * Previous device IDs where access codes existed.
+         */
         public array|null $device_ids,
+        /**
+         * Previous end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * Previous start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * List of pending mutations for the access grant. This shows updates that are in progress.
+ */
 class UnmanagedAccessGrantPendingMutations
 {
     public static function from_json(
@@ -153,15 +246,36 @@ class UnmanagedAccessGrantPendingMutations
     }
 
     public function __construct(
+        /**
+         * IDs of the access methods being updated.
+         */
         public array|null $access_method_ids,
+        /**
+         * Date and time at which the mutation was created.
+         */
         public string|null $created_at,
+        /**
+         * Previous location configuration.
+         */
         public UnmanagedAccessGrantFrom|null $from,
+        /**
+         * Detailed description of the mutation.
+         */
         public string|null $message,
+        /**
+         * Mutation code to indicate that Seam is in the process of updating the spaces (devices) associated with this access grant.
+         */
         public string|null $mutation_code,
+        /**
+         * New location configuration.
+         */
         public UnmanagedAccessGrantTo|null $to,
     ) {}
 }
 
+/**
+ * Access methods that the user requested for the Access Grant.
+ */
 class UnmanagedAccessGrantRequestedAccessMethods
 {
     public static function from_json(
@@ -181,15 +295,36 @@ class UnmanagedAccessGrantRequestedAccessMethods
     }
 
     public function __construct(
+        /**
+         * Specific PIN code to use for this access method. Only applicable when mode is 'code'.
+         */
         public string|null $code,
+        /**
+         * IDs of the access methods created for the requested access method.
+         */
         public array|null $created_access_method_ids,
+        /**
+         * Date and time at which the requested access method was added to the Access Grant.
+         */
         public string|null $created_at,
+        /**
+         * Display name of the access method.
+         */
         public string|null $display_name,
+        /**
+         * Maximum number of times the instant key can be used. Only applicable when mode is 'mobile_key'. Defaults to 1 if not specified.
+         */
         public int|null $instant_key_max_use_count,
+        /**
+         * Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+         */
         public string|null $mode,
     ) {}
 }
 
+/**
+ * New location configuration.
+ */
 class UnmanagedAccessGrantTo
 {
     public static function from_json(mixed $json): UnmanagedAccessGrantTo|null
@@ -206,13 +341,28 @@ class UnmanagedAccessGrantTo
     }
 
     public function __construct(
+        /**
+         * Common code key to ensure PIN code reuse across devices.
+         */
         public string|null $common_code_key,
+        /**
+         * New device IDs where access codes should be created.
+         */
         public array|null $device_ids,
+        /**
+         * New end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * New start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Warnings associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+ */
 class UnmanagedAccessGrantWarnings
 {
     public static function from_json(
@@ -238,14 +388,41 @@ class UnmanagedAccessGrantWarnings
     }
 
     public function __construct(
+        /**
+         * IDs of the access methods being updated.
+         */
         public array|null $access_method_ids,
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * ID of the device where the requested code was unavailable.
+         */
         public string|null $device_id,
+        /**
+         * Devices whose access codes could not be revoked during reconciliation. Present when the provider does not support revoking an offline access code (e.g. Dormakaba oracode with exhausted override budget).
+         */
         public array $failed_devices,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * The new PIN code that was assigned instead.
+         */
         public string|null $new_code,
+        /**
+         * The originally requested PIN code that was unavailable.
+         */
         public string|null $original_code,
+        /**
+         * Specific reason why the grant's times are not programmable on the device.
+         */
         public string|null $reason,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/UnmanagedAccessMethod.php
+++ b/src/Resources/UnmanagedAccessMethod.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an unmanaged access method. Unmanaged access methods do not have client sessions, instant keys, customization profiles, or keys.
+ */
 class UnmanagedAccessMethod
 {
     public static function from_json(mixed $json): UnmanagedAccessMethod|null
@@ -38,24 +41,72 @@ class UnmanagedAccessMethod
     }
 
     public function __construct(
+        /**
+         * ID of the access method.
+         */
         public string|null $access_method_id,
+        /**
+         * The actual PIN code for code access methods.
+         */
         public string|null $code,
+        /**
+         * Date and time at which the access method was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name of the access method.
+         */
         public string|null $display_name,
+        /**
+         * Errors associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+         */
         public array $errors,
+        /**
+         * Indicates whether an existing card credential must be assigned to this access method before it can be issued. Only applies to card-mode access methods on systems that support credential assignment.
+         */
         public bool|null $is_assignment_required,
+        /**
+         * Indicates whether encoding with an card encoder is required to issue or reissue the plastic card associated with the access method.
+         */
         public bool|null $is_encoding_required,
+        /**
+         * Indicates whether the access method has been issued.
+         */
         public bool|null $is_issued,
+        /**
+         * Indicates whether the access method is ready for card assignment. This is true when the access method is in card mode, has not yet been issued, and the system supports credential assignment.
+         */
         public bool|null $is_ready_for_assignment,
+        /**
+         * Indicates whether the access method is ready to be encoded. This is true when the credential has been created and the card has not yet been issued.
+         */
         public bool|null $is_ready_for_encoding,
+        /**
+         * Date and time at which the access method was issued.
+         */
         public string|null $issued_at,
+        /**
+         * Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+         */
         public string|null $mode,
+        /**
+         * Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
+         */
         public array $pending_mutations,
+        /**
+         * Warnings associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+         */
         public array $warnings,
+        /**
+         * ID of the Seam workspace associated with the access method.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Errors associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+ */
 class UnmanagedAccessMethodErrors
 {
     public static function from_json(
@@ -72,12 +123,24 @@ class UnmanagedAccessMethodErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Previous device configuration.
+ */
 class UnmanagedAccessMethodFrom
 {
     public static function from_json(
@@ -94,12 +157,24 @@ class UnmanagedAccessMethodFrom
     }
 
     public function __construct(
+        /**
+         * Previous device IDs where access was provisioned.
+         */
         public array|null $device_ids,
+        /**
+         * Previous end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * Previous start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
+ */
 class UnmanagedAccessMethodPendingMutations
 {
     public static function from_json(
@@ -122,14 +197,32 @@ class UnmanagedAccessMethodPendingMutations
     }
 
     public function __construct(
+        /**
+         * Date and time at which the mutation was created.
+         */
         public string|null $created_at,
+        /**
+         * Previous device configuration.
+         */
         public UnmanagedAccessMethodFrom|null $from,
+        /**
+         * Detailed description of the mutation.
+         */
         public string|null $message,
+        /**
+         * Mutation code to indicate that Seam is in the process of provisioning access for this access method on new devices.
+         */
         public string|null $mutation_code,
+        /**
+         * New device configuration.
+         */
         public UnmanagedAccessMethodTo|null $to,
     ) {}
 }
 
+/**
+ * New device configuration.
+ */
 class UnmanagedAccessMethodTo
 {
     public static function from_json(mixed $json): UnmanagedAccessMethodTo|null
@@ -145,12 +238,24 @@ class UnmanagedAccessMethodTo
     }
 
     public function __construct(
+        /**
+         * New device IDs where access is being provisioned.
+         */
         public array|null $device_ids,
+        /**
+         * New end time for access.
+         */
         public string|null $ends_at,
+        /**
+         * New start time for access.
+         */
         public string|null $starts_at,
     ) {}
 }
 
+/**
+ * Warnings associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+ */
 class UnmanagedAccessMethodWarnings
 {
     public static function from_json(
@@ -168,9 +273,21 @@ class UnmanagedAccessMethodWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * ID of the original access method from which this backup access method was split, if applicable.
+         */
         public string|null $original_access_method_id,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/UnmanagedDevice.php
+++ b/src/Resources/UnmanagedDevice.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+ */
 class UnmanagedDevice
 {
     public static function from_json(mixed $json): UnmanagedDevice|null
@@ -66,41 +69,140 @@ class UnmanagedDevice
     }
 
     public function __construct(
+        /**
+         * Indicates whether the lock supports configuring automatic locking.
+         */
         public bool|null $can_configure_auto_lock,
+        /**
+         * Indicates whether the thermostat supports cooling.
+         */
         public bool|null $can_hvac_cool,
+        /**
+         * Indicates whether the thermostat supports heating.
+         */
         public bool|null $can_hvac_heat,
+        /**
+         * Indicates whether the thermostat supports simultaneous heating and cooling.
+         */
         public bool|null $can_hvac_heat_cool,
+        /**
+         * Indicates whether the device supports programming offline access codes.
+         */
         public bool|null $can_program_offline_access_codes,
+        /**
+         * Indicates whether the device supports programming online access codes.
+         */
         public bool|null $can_program_online_access_codes,
+        /**
+         * Indicates whether the thermostat supports different climate programs for each day of the week.
+         */
         public bool|null $can_program_thermostat_programs_as_different_each_day,
+        /**
+         * Indicates whether the thermostat supports a single climate program applied to every day.
+         */
         public bool|null $can_program_thermostat_programs_as_same_each_day,
+        /**
+         * Indicates whether the thermostat supports weekday/weekend climate programs.
+         */
         public bool|null $can_program_thermostat_programs_as_weekday_weekend,
+        /**
+         * Indicates whether the device supports remote locking.
+         */
         public bool|null $can_remotely_lock,
+        /**
+         * Indicates whether the device supports remote unlocking.
+         */
         public bool|null $can_remotely_unlock,
+        /**
+         * Indicates whether the thermostat supports running climate programs.
+         */
         public bool|null $can_run_thermostat_programs,
+        /**
+         * Indicates whether the device supports simulating connection in a sandbox.
+         */
         public bool|null $can_simulate_connection,
+        /**
+         * Indicates whether the device supports simulating disconnection in a sandbox.
+         */
         public bool|null $can_simulate_disconnection,
+        /**
+         * Indicates whether the hub supports simulating connection in a sandbox.
+         */
         public bool|null $can_simulate_hub_connection,
+        /**
+         * Indicates whether the hub supports simulating disconnection in a sandbox.
+         */
         public bool|null $can_simulate_hub_disconnection,
+        /**
+         * Indicates whether the device supports simulating a paid subscription in a sandbox.
+         */
         public bool|null $can_simulate_paid_subscription,
+        /**
+         * Indicates whether the device supports simulating removal in a sandbox.
+         */
         public bool|null $can_simulate_removal,
+        /**
+         * Indicates whether the thermostat can be turned off.
+         */
         public bool|null $can_turn_off_hvac,
+        /**
+         * Indicates whether the lock supports unlocking with an access code.
+         */
         public bool|null $can_unlock_with_code,
+        /**
+         * Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
+         */
         public array|null $capabilities_supported,
+        /**
+         * Unique identifier for the account associated with the device.
+         */
         public string|null $connected_account_id,
+        /**
+         * Date and time at which the device object was created.
+         */
         public string|null $created_at,
+        /**
+         * Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.
+         */
         public mixed $custom_metadata,
+        /**
+         * ID of the device.
+         */
         public string|null $device_id,
+        /**
+         * Type of the device.
+         */
         public string|null $device_type,
+        /**
+         * Array of errors associated with the device. Each error object within the array contains two fields: `error_code` and `message`. `error_code` is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+         */
         public array $errors,
+        /**
+         * Indicates that Seam does not manage the device.
+         */
         public bool|null $is_managed,
+        /**
+         * Location information for the device.
+         */
         public UnmanagedDeviceLocation|null $location,
+        /**
+         * properties of the device.
+         */
         public UnmanagedDeviceProperties|null $properties,
+        /**
+         * Array of warnings associated with the device. Each warning object within the array contains two fields: `warning_code` and `message`. `warning_code` is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+         */
         public array $warnings,
+        /**
+         * Unique identifier for the Seam workspace associated with the device.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Accessory keypad properties and state.
+ */
 class UnmanagedDeviceAccessoryKeypad
 {
     public static function from_json(
@@ -118,11 +220,20 @@ class UnmanagedDeviceAccessoryKeypad
     }
 
     public function __construct(
+        /**
+         * Keypad battery properties.
+         */
         public UnmanagedDeviceBattery|null $battery,
+        /**
+         * Indicates if an accessory keypad is connected to the device.
+         */
         public bool|null $is_connected,
     ) {}
 }
 
+/**
+ * Keypad battery properties.
+ */
 class UnmanagedDeviceBattery
 {
     public static function from_json(mixed $json): UnmanagedDeviceBattery|null
@@ -136,6 +247,9 @@ class UnmanagedDeviceBattery
     public function __construct(public float|null $level) {}
 }
 
+/**
+ * Array of errors associated with the device. Each error object within the array contains two fields: `error_code` and `message`. `error_code` is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+ */
 class UnmanagedDeviceErrors
 {
     public static function from_json(mixed $json): UnmanagedDeviceErrors|null
@@ -155,15 +269,36 @@ class UnmanagedDeviceErrors
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+         */
         public bool|null $is_bridge_error,
+        /**
+         * Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+         */
         public bool|null $is_connected_account_error,
+        /**
+         * Indicates that the error is not a device error.
+         */
         public bool|null $is_device_error,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Location information for the device.
+ */
 class UnmanagedDeviceLocation
 {
     public static function from_json(mixed $json): UnmanagedDeviceLocation|null
@@ -179,12 +314,26 @@ class UnmanagedDeviceLocation
     }
 
     public function __construct(
+        /**
+         * Name of the device location.
+         */
         public string|null $location_name,
+        /**
+         * Time zone of the device location.
+         */
         public string|null $time_zone,
+        /**
+         * Time zone of the device location.
+         *
+         * @deprecated Use `time_zone` instead.
+         */
         public string|null $timezone,
     ) {}
 }
 
+/**
+ * Device model-related properties.
+ */
 class UnmanagedDeviceModel
 {
     public static function from_json(mixed $json): UnmanagedDeviceModel|null
@@ -208,16 +357,40 @@ class UnmanagedDeviceModel
     }
 
     public function __construct(
+        /**
+         * @deprecated use device.properties.model.can_connect_accessory_keypad
+         */
         public bool|null $accessory_keypad_supported,
+        /**
+         * Indicates whether the device can connect a accessory keypad.
+         */
         public bool|null $can_connect_accessory_keypad,
+        /**
+         * Display name of the device model.
+         */
         public string|null $display_name,
+        /**
+         * Indicates whether the device has a built in accessory keypad.
+         */
         public bool|null $has_built_in_keypad,
+        /**
+         * Display name that corresponds to the manufacturer-specific terminology for the device.
+         */
         public string|null $manufacturer_display_name,
+        /**
+         * @deprecated use device.can_program_offline_access_codes.
+         */
         public bool|null $offline_access_codes_supported,
+        /**
+         * @deprecated use device.can_program_online_access_codes.
+         */
         public bool|null $online_access_codes_supported,
     ) {}
 }
 
+/**
+ * properties of the device.
+ */
 class UnmanagedDeviceProperties
 {
     public static function from_json(
@@ -252,20 +425,62 @@ class UnmanagedDeviceProperties
     }
 
     public function __construct(
+        /**
+         * Accessory keypad properties and state.
+         */
         public UnmanagedDeviceAccessoryKeypad|null $accessory_keypad,
+        /**
+         * Represents the current status of the battery charge level.
+         */
         public UnmanagedDeviceBattery|null $battery,
+        /**
+         * Indicates the battery level of the device as a decimal value between 0 and 1, inclusive.
+         */
         public float|null $battery_level,
+        /**
+         * Alt text for the device image.
+         */
         public string|null $image_alt_text,
+        /**
+         * Image URL for the device.
+         */
         public string|null $image_url,
+        /**
+         * Manufacturer of the device. When a device, such as a smart lock, is connected through a smart hub, the manufacturer of the device might be different from that of the smart hub.
+         */
         public string|null $manufacturer,
+        /**
+         * Device model-related properties.
+         */
         public UnmanagedDeviceModel|null $model,
+        /**
+         * Name of the device.
+         *
+         * @deprecated use device.display_name instead
+         */
         public string|null $name,
+        /**
+         * Indicates whether it is currently possible to use offline access codes for the device.
+         *
+         * @deprecated use device.can_program_offline_access_codes
+         */
         public bool|null $offline_access_codes_enabled,
+        /**
+         * Indicates whether the device is online.
+         */
         public bool|null $online,
+        /**
+         * Indicates whether it is currently possible to use online access codes for the device.
+         *
+         * @deprecated use device.can_program_online_access_codes
+         */
         public bool|null $online_access_codes_enabled,
     ) {}
 }
 
+/**
+ * Array of warnings associated with the device. Each warning object within the array contains two fields: `warning_code` and `message`. `warning_code` is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+ */
 class UnmanagedDeviceWarnings
 {
     public static function from_json(mixed $json): UnmanagedDeviceWarnings|null
@@ -284,10 +499,25 @@ class UnmanagedDeviceWarnings
     }
 
     public function __construct(
+        /**
+         * Number of active access codes on the device when the warning was set.
+         */
         public int|null $active_access_code_count,
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Maximum number of active access codes supported by the device.
+         */
         public int|null $max_active_access_code_count,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/UnmanagedUserIdentity.php
+++ b/src/Resources/UnmanagedUserIdentity.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents an unmanaged user identity. Unmanaged user identities do not have keys.
+ */
 class UnmanagedUserIdentity
 {
     public static function from_json(mixed $json): UnmanagedUserIdentity|null
@@ -30,19 +33,52 @@ class UnmanagedUserIdentity
     }
 
     public function __construct(
+        /**
+         * Array of access system user IDs associated with the user identity.
+         */
         public array|null $acs_user_ids,
+        /**
+         * Date and time at which the user identity was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name for the user identity.
+         */
         public string|null $display_name,
+        /**
+         * Unique email address for the user identity.
+         */
         public string|null $email_address,
+        /**
+         * Array of errors associated with the user identity. Each error object within the array contains fields like "error_code" and "message." "error_code" is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+         */
         public array $errors,
+        /**
+         * Full name of the user associated with the user identity.
+         */
         public string|null $full_name,
+        /**
+         * Unique phone number for the user identity in [E.164 format](https://www.itu.int/rec/T-REC-E.164/en) (for example, +15555550100).
+         */
         public string|null $phone_number,
+        /**
+         * ID of the user identity.
+         */
         public string|null $user_identity_id,
+        /**
+         * Array of warnings associated with the user identity. Each warning object within the array contains two fields: "warning_code" and "message." "warning_code" is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+         */
         public array $warnings,
+        /**
+         * ID of the workspace that contains the user identity.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Array of errors associated with the user identity. Each error object within the array contains fields like "error_code" and "message." "error_code" is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+ */
 class UnmanagedUserIdentityErrors
 {
     public static function from_json(
@@ -61,14 +97,32 @@ class UnmanagedUserIdentityErrors
     }
 
     public function __construct(
+        /**
+         * ID of the access system that the user identity is associated with.
+         */
         public string|null $acs_system_id,
+        /**
+         * ID of the access system user that has an issue.
+         */
         public string|null $acs_user_id,
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Array of warnings associated with the user identity. Each warning object within the array contains two fields: "warning_code" and "message." "warning_code" is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+ */
 class UnmanagedUserIdentityWarnings
 {
     public static function from_json(
@@ -85,8 +139,17 @@ class UnmanagedUserIdentityWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/UserIdentity.php
+++ b/src/Resources/UserIdentity.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with an application user account.
+ */
 class UserIdentity
 {
     public static function from_json(mixed $json): UserIdentity|null
@@ -31,20 +34,56 @@ class UserIdentity
     }
 
     public function __construct(
+        /**
+         * Array of access system user IDs associated with the user identity.
+         */
         public array|null $acs_user_ids,
+        /**
+         * Date and time at which the user identity was created.
+         */
         public string|null $created_at,
+        /**
+         * Display name for the user identity.
+         */
         public string|null $display_name,
+        /**
+         * Unique email address for the user identity.
+         */
         public string|null $email_address,
+        /**
+         * Array of errors associated with the user identity. Each error object within the array contains fields like "error_code" and "message." "error_code" is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+         */
         public array $errors,
+        /**
+         * Full name of the user associated with the user identity.
+         */
         public string|null $full_name,
+        /**
+         * Unique phone number for the user identity in [E.164 format](https://www.itu.int/rec/T-REC-E.164/en) (for example, +15555550100).
+         */
         public string|null $phone_number,
+        /**
+         * ID of the user identity.
+         */
         public string|null $user_identity_id,
+        /**
+         * Unique key for the user identity.
+         */
         public string|null $user_identity_key,
+        /**
+         * Array of warnings associated with the user identity. Each warning object within the array contains two fields: "warning_code" and "message." "warning_code" is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+         */
         public array $warnings,
+        /**
+         * ID of the workspace that contains the user identity.
+         */
         public string|null $workspace_id,
     ) {}
 }
 
+/**
+ * Array of errors associated with the user identity. Each error object within the array contains fields like "error_code" and "message." "error_code" is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+ */
 class UserIdentityErrors
 {
     public static function from_json(mixed $json): UserIdentityErrors|null
@@ -62,14 +101,32 @@ class UserIdentityErrors
     }
 
     public function __construct(
+        /**
+         * ID of the access system that the user identity is associated with.
+         */
         public string|null $acs_system_id,
+        /**
+         * ID of the access system user that has an issue.
+         */
         public string|null $acs_user_id,
+        /**
+         * Date and time at which Seam created the error.
+         */
         public string|null $created_at,
+        /**
+         * Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+         */
         public string|null $error_code,
+        /**
+         * Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
     ) {}
 }
 
+/**
+ * Array of warnings associated with the user identity. Each warning object within the array contains two fields: "warning_code" and "message." "warning_code" is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. "message" provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+ */
 class UserIdentityWarnings
 {
     public static function from_json(mixed $json): UserIdentityWarnings|null
@@ -85,8 +142,17 @@ class UserIdentityWarnings
     }
 
     public function __construct(
+        /**
+         * Date and time at which Seam created the warning.
+         */
         public string|null $created_at,
+        /**
+         * Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+         */
         public string|null $message,
+        /**
+         * Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+         */
         public string|null $warning_code,
     ) {}
 }

--- a/src/Resources/Webhook.php
+++ b/src/Resources/Webhook.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a [webhook](https://docs.seam.co/developer-tools/webhooks) that enables you to receive notifications of events. When you create a webhook, specify the endpoint URL at which you want to receive events and the set of event types that you want to receive.
+ */
 class Webhook
 {
     public static function from_json(mixed $json): Webhook|null
@@ -18,9 +21,21 @@ class Webhook
     }
 
     public function __construct(
+        /**
+         * Types of events that the [webhook](https://docs.seam.co/developer-tools/webhooks) should receive.
+         */
         public array|null $event_types,
+        /**
+         * Secret associated with the [webhook](https://docs.seam.co/developer-tools/webhooks).
+         */
         public string|null $secret,
+        /**
+         * URL for the [webhook](https://docs.seam.co/developer-tools/webhooks).
+         */
         public string|null $url,
+        /**
+         * ID of the webhook.
+         */
         public string|null $webhook_id,
     ) {}
 }

--- a/src/Resources/Workspace.php
+++ b/src/Resources/Workspace.php
@@ -2,6 +2,9 @@
 
 namespace Seam\Resources;
 
+/**
+ * Represents a Seam [workspace](https://docs.seam.co/core-concepts/workspaces). A workspace is a top-level entity that encompasses all other resources below it, such as devices, connected accounts, and Connect Webviews. Seam provides two types of workspaces. A [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is a special type of workspace designed for testing code. Sandbox workspaces offer test device accounts and virtual devices that you can connect and control. This ability to work with virtual devices is quite handy because it removes the need to own physical devices from multiple brands. To connect real devices and systems to Seam, use a [production workspace](https://docs.seam.co/core-concepts/workspaces#production-workspaces).
+ */
 class Workspace
 {
     public static function from_json(mixed $json): Workspace|null
@@ -31,15 +34,42 @@ class Workspace
     }
 
     public function __construct(
+        /**
+         * Company name associated with the [workspace](https://docs.seam.co/core-concepts/workspaces).
+         */
         public string|null $company_name,
+        /**
+         * @deprecated Use `company_name` instead.
+         */
         public string|null $connect_partner_name,
         public WorkspaceConnectWebviewCustomization|null $connect_webview_customization,
+        /**
+         * Indicates whether publishable key authentication is enabled for this workspace.
+         */
         public bool|null $is_publishable_key_auth_enabled,
+        /**
+         * Indicates whether the workspace is a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+         */
         public bool|null $is_sandbox,
+        /**
+         * Indicates whether the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is suspended. Seam suspends sandbox workspaces that have not been accessed in 14 days.
+         */
         public bool|null $is_suspended,
+        /**
+         * Name of the [workspace](https://docs.seam.co/core-concepts/workspaces).
+         */
         public string|null $name,
+        /**
+         * ID of the organization to which the workspace belongs, or `null` if the workspace is not assigned to an organization.
+         */
         public string|null $organization_id,
+        /**
+         * Publishable key for the [workspace](https://docs.seam.co/core-concepts/workspaces). This key is used to identify the workspace in client-side applications.
+         */
         public string|null $publishable_key,
+        /**
+         * ID of the workspace.
+         */
         public string|null $workspace_id,
     ) {}
 }
@@ -62,10 +92,25 @@ class WorkspaceConnectWebviewCustomization
     }
 
     public function __construct(
+        /**
+         * URL of the inviter logo for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+         */
         public string|null $inviter_logo_url,
+        /**
+         * Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+         */
         public string|null $logo_shape,
+        /**
+         * Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+         */
         public string|null $primary_button_color,
+        /**
+         * Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+         */
         public string|null $primary_button_text_color,
+        /**
+         * Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+         */
         public string|null $success_message,
     ) {}
 }

--- a/src/SeamClient.php
+++ b/src/SeamClient.php
@@ -180,6 +180,33 @@ class AccessCodesClient
         $this->unmanaged = new AccessCodesUnmanagedClient($seam);
     }
 
+    /**
+     * Creates a new [access code](https://docs.seam.co/low-level-apis/access-codes). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they work across both standalone smart locks and access control systems and manage the underlying codes for you. Use this low-level endpoint only when you need direct control over a code on a single device, such as setting a custom PIN value.
+     *
+     * @param string $device_id ID of the device for which you want to create the new access code.
+     * @param bool $allow_external_modification Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+     * @param bool $attempt_for_offline_device
+     * @param string $code Code to be used for access.
+     * @param string $common_code_key Key to identify access codes that should have the same code. Any two access codes with the same `common_code_key` are guaranteed to have the same `code`. See also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).
+     * @param string $ends_at Date and time at which the validity of the new access code ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+     * @param bool $is_external_modification_allowed Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+     * @param bool $is_offline_access_code Indicates whether the access code is an [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes).
+     * @param bool $is_one_time_use Indicates whether the [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) is a single-use access code.
+     * @param string $max_time_rounding Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.
+     * @param string $name Name of the new access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes.
+
+Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider's app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`.
+
+To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider's app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints.
+
+To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+     * @param bool $prefer_native_scheduling Indicates whether [native scheduling](https://docs.seam.co/low-level-apis/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.
+     * @param float $preferred_code_length Preferred code length. Only applicable if you do not specify a `code`. If the affected device does not support the preferred code length, Seam reverts to using the shortest supported code length.
+     * @param string $starts_at Date and time at which the validity of the new access code starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @param bool $use_backup_access_code_pool Indicates whether to use a [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).
+     * @param bool $use_offline_access_code
+     * @return AccessCode OK
+     */
     public function create(
         string $device_id,
         ?bool $allow_external_modification = null,
@@ -272,6 +299,39 @@ class AccessCodesClient
         return AccessCode::from_json($res->access_code);
     }
 
+    /**
+     * Creates new [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+     *
+     * Users with more than one door lock in a property may want to create groups of linked access codes, all of which have the same code (PIN). For example, a short-term rental host may want to provide guests the same PIN for both a front door lock and a back door lock.
+     *
+     * If you specify a custom code, Seam assigns this custom code to each of the resulting access codes. However, in this case, Seam does not link these access codes together with a `common_code_key`. That is, `common_code_key` remains null for these access codes.
+     *
+     * If you want to change these access codes that are not linked by a `common_code_key`, you cannot use `/access_codes/update_multiple`. However, you can update each of these access codes individually, using `/access_codes/update`.
+     *
+     * See also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).
+     *
+     * For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
+     *
+     * @param array $device_ids IDs of the devices for which you want to create the new access codes.
+     * @param bool $allow_external_modification Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+     * @param bool $attempt_for_offline_device
+     * @param string $behavior_when_code_cannot_be_shared Desired behavior if any device cannot share a code. If `throw` (default), no access codes will be created if any device cannot share a code. If `create_random_code`, a random code will be created on devices that cannot share a code.
+     * @param string $code Code to be used for access.
+     * @param string $ends_at Date and time at which the validity of the new access code ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+     * @param bool $is_external_modification_allowed Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+     * @param string $name Name of the new access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes.
+
+Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider's app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`.
+
+To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider's app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints.
+
+To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+     * @param bool $prefer_native_scheduling Indicates whether [native scheduling](https://docs.seam.co/low-level-apis/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.
+     * @param float $preferred_code_length Preferred code length. If the affected devices do not support the preferred code length, Seam reverts to using the shortest supported code length.
+     * @param string $starts_at Date and time at which the validity of the new access code starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @param bool $use_backup_access_code_pool Indicates whether to use a [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).
+     * @return array OK
+     */
     public function create_multiple(
         array $device_ids,
         ?bool $allow_external_modification = null,
@@ -349,6 +409,13 @@ class AccessCodesClient
         );
     }
 
+    /**
+     * Deletes an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+     *
+     * @param string $access_code_id ID of the access code that you want to delete.
+     * @param string $device_id ID of the device for which you want to delete the access code.
+     * @return void OK
+     */
     public function delete(
         string $access_code_id,
         ?string $device_id = null,
@@ -369,6 +436,12 @@ class AccessCodesClient
         );
     }
 
+    /**
+     * Generates a code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes), given a device ID.
+     *
+     * @param string $device_id ID of the device for which you want to generate a code.
+     * @return AccessCode OK
+     */
     public function generate_code(string $device_id): AccessCode
     {
         $request_payload = [];
@@ -386,6 +459,16 @@ class AccessCodesClient
         return AccessCode::from_json($res->generated_code);
     }
 
+    /**
+     * Returns a specified [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+     *
+     * You must specify either `access_code_id` or both `device_id` and `code`.
+     *
+     * @param string $access_code_id ID of the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     * @param string $code Code of the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     * @param string $device_id ID of the device containing the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     * @return AccessCode OK
+     */
     public function get(
         ?string $access_code_id = null,
         ?string $code = null,
@@ -412,6 +495,23 @@ class AccessCodesClient
         return AccessCode::from_json($res->access_code);
     }
 
+    /**
+     * Returns a list of all [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+     *
+     * Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     *
+     * @param array $access_code_ids IDs of the access codes that you want to retrieve. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     * @param string $access_grant_id ID of the access grant for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     * @param string $access_grant_key Key of the access grant for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     * @param string $access_method_id ID of the access method for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     * @param string $customer_key Customer key for which you want to list access codes.
+     * @param string $device_id ID of the device for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+     * @param float $limit Numerical limit on the number of access codes to return.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned access codes to include all records that satisfy a partial match using `name`, `code` or `access_code_id`.
+     * @param string $user_identifier_key Your user ID for the user by which to filter access codes.
+     * @return array OK
+     */
     public function list(
         ?array $access_code_ids = null,
         ?string $access_grant_id = null,
@@ -474,6 +574,20 @@ class AccessCodesClient
         );
     }
 
+    /**
+     * Retrieves a backup access code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes). See also [Managing Backup Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes).
+     *
+     * A backup access code pool is a collection of pre-programmed access codes stored on a device, ready for use. These codes are programmed in addition to the regular access codes on Seam, serving as a safety net for any issues with the primary codes. If there's ever a complication with a primary access code—be it due to intermittent connectivity, manual removal from a device, or provider outages—a backup code can be retrieved. Its end time can then be adjusted to align with the original code, facilitating seamless and uninterrupted access.
+     *
+     * You can pull a backup access code from the pool at any time. These backup codes are guaranteed to work immediately and automatically programmed to be removed from the device after the access code ends.
+     *
+     * You can only pull backup access codes for time-bound access codes.
+     *
+     * Before pulling a backup access code, make sure that the device's `properties.supports_backup_access_code_pool` is `true`. Then, to activate the backup pool, set `use_backup_access_code_pool` to `true` when creating an access code.
+     *
+     * @param string $access_code_id ID of the access code for which you want to pull a backup access code.
+     * @return AccessCode OK
+     */
     public function pull_backup_access_code(string $access_code_id): AccessCode
     {
         $request_payload = [];
@@ -491,6 +605,17 @@ class AccessCodesClient
         return AccessCode::from_json($res->access_code);
     }
 
+    /**
+     * Enables you to report access code-related constraints for a device. Currently, supports reporting supported code length constraints for SmartThings devices.
+     *
+     * Specify either `supported_code_lengths` or `min_code_length`/`max_code_length`.
+     *
+     * @param string $device_id ID of the device for which you want to report constraints.
+     * @param int $max_code_length Maximum supported code length as an integer between 4 and 20, inclusive. You can specify either `min_code_length`/`max_code_length` or `supported_code_lengths`.
+     * @param int $min_code_length Minimum supported code length as an integer between 4 and 20, inclusive. You can specify either `min_code_length`/`max_code_length` or `supported_code_lengths`.
+     * @param array $supported_code_lengths Array of supported code lengths as integers between 4 and 20, inclusive. You can specify either `supported_code_lengths` or `min_code_length`/`max_code_length`.
+     * @return void OK
+     */
     public function report_device_constraints(
         string $device_id,
         ?int $max_code_length = null,
@@ -521,6 +646,37 @@ class AccessCodesClient
         );
     }
 
+    /**
+     * Updates a specified active or upcoming [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+     *
+     * See also [Modifying Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes).
+     *
+     * @param string $access_code_id ID of the access code that you want to update.
+     * @param bool $allow_external_modification Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+     * @param bool $attempt_for_offline_device
+     * @param string $code Code to be used for access.
+     * @param string $device_id ID of the device containing the access code that you want to update.
+     * @param string $ends_at Date and time at which the validity of the new access code ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+     * @param bool $is_external_modification_allowed Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+     * @param bool $is_managed Indicates whether the access code is managed through Seam. Note that to convert an unmanaged access code into a managed access code, use `/access_codes/unmanaged/convert_to_managed`.
+     * @param bool $is_offline_access_code Indicates whether the access code is an [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes).
+     * @param bool $is_one_time_use Indicates whether the [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) is a single-use access code.
+     * @param string $max_time_rounding Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.
+     * @param string $name Name of the new access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes.
+
+Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider's app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`.
+
+To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider's app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints.
+
+To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+     * @param bool $prefer_native_scheduling Indicates whether [native scheduling](https://docs.seam.co/low-level-apis/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.
+     * @param float $preferred_code_length Preferred code length. Only applicable if you do not specify a `code`. If the affected device does not support the preferred code length, Seam reverts to using the shortest supported code length.
+     * @param string $starts_at Date and time at which the validity of the new access code starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @param string $type Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set `type` to `ongoing`. See also [Changing a time-bound access code to permanent access](https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access).
+     * @param bool $use_backup_access_code_pool Indicates whether to use a [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).
+     * @param bool $use_offline_access_code
+     * @return void OK
+     */
     public function update(
         string $access_code_id,
         ?bool $allow_external_modification = null,
@@ -619,6 +775,25 @@ class AccessCodesClient
         );
     }
 
+    /**
+     * Updates [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+     *
+     * Specify the `common_code_key` to identify the set of access codes that you want to update.
+     *
+     * See also [Update Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes#update-linked-access-codes).
+     *
+     * @param string $common_code_key Key that links the group of access codes, assigned on creation by `/access_codes/create_multiple`.
+     * @param string $ends_at Date and time at which the validity of the new access code ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+     * @param string $name Name of the new access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes.
+
+Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider's app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`.
+
+To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider's app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints.
+
+To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+     * @param string $starts_at Date and time at which the validity of the new access code starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @return void OK
+     */
     public function update_multiple(
         string $common_code_key,
         ?string $ends_at = null,
@@ -657,6 +832,14 @@ class AccessCodesSimulateClient
         $this->seam = $seam;
     }
 
+    /**
+     * Simulates the creation of an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     *
+     * @param string $code Code of the simulated unmanaged access code.
+     * @param string $device_id ID of the device for which you want to simulate the creation of an unmanaged access code.
+     * @param string $name Name of the simulated unmanaged access code.
+     * @return UnmanagedAccessCode OK
+     */
     public function create_unmanaged_access_code(
         string $code,
         string $device_id,
@@ -693,6 +876,19 @@ class AccessCodesUnmanagedClient
         $this->seam = $seam;
     }
 
+    /**
+     * Converts an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) to an [access code managed through Seam](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+     *
+     * An unmanaged access code has a limited set of operations that you can perform on it. Once you convert an unmanaged access code to a managed access code, the full set of access code operations and lifecycle events becomes available for it.
+     *
+     * Note that not all device providers support converting an unmanaged access code to a managed access code.
+     *
+     * @param string $access_code_id ID of the unmanaged access code that you want to convert to a managed access code.
+     * @param bool $allow_external_modification Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the access code is allowed.
+     * @param bool $force Indicates whether to force the access code conversion. To switch management of an access code from one Seam workspace to another, set `force` to `true`.
+     * @param bool $is_external_modification_allowed Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the access code is allowed.
+     * @return void OK
+     */
     public function convert_to_managed(
         string $access_code_id,
         ?bool $allow_external_modification = null,
@@ -725,6 +921,12 @@ class AccessCodesUnmanagedClient
         );
     }
 
+    /**
+     * Deletes an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+     *
+     * @param string $access_code_id ID of the unmanaged access code that you want to delete.
+     * @return void OK
+     */
     public function delete(string $access_code_id): void
     {
         $request_payload = [];
@@ -740,6 +942,16 @@ class AccessCodesUnmanagedClient
         );
     }
 
+    /**
+     * Returns a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+     *
+     * You must specify either `access_code_id` or both `device_id` and `code`.
+     *
+     * @param string $access_code_id ID of the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     * @param string $code Code of the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     * @param string $device_id ID of the device containing the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+     * @return UnmanagedAccessCode OK
+     */
     public function get(
         ?string $access_code_id = null,
         ?string $code = null,
@@ -766,6 +978,16 @@ class AccessCodesUnmanagedClient
         return UnmanagedAccessCode::from_json($res->access_code);
     }
 
+    /**
+     * Returns a list of all [unmanaged access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+     *
+     * @param string $device_id ID of the device for which you want to list unmanaged access codes.
+     * @param float $limit Numerical limit on the number of unmanaged access codes to return.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned access codes to include all records that satisfy a partial match using `name`, `code` or `access_code_id`.
+     * @param string $user_identifier_key Your user ID for the user by which to filter unmanaged access codes.
+     * @return array OK
+     */
     public function list(
         string $device_id,
         ?float $limit = null,
@@ -808,6 +1030,16 @@ class AccessCodesUnmanagedClient
         );
     }
 
+    /**
+     * Updates a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+     *
+     * @param string $access_code_id ID of the unmanaged access code that you want to update.
+     * @param bool $is_managed
+     * @param bool $allow_external_modification Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed.
+     * @param bool $force Indicates whether to force the unmanaged access code update.
+     * @param bool $is_external_modification_allowed Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed.
+     * @return void OK
+     */
     public function update(
         string $access_code_id,
         bool $is_managed,
@@ -855,6 +1087,26 @@ class AccessGrantsClient
         $this->unmanaged = new AccessGrantsUnmanagedClient($seam);
     }
 
+    /**
+     * Creates a new [Access Grant](https://docs.seam.co/use-cases/granting-access/access-grants). Access Grants are the default and recommended way to grant a user access to any physical space, irrespective of the locking hardware. They work with both standalone smart locks (using `device_ids`) and access control systems (using `acs_entrance_ids` or `space_ids`), and can issue PIN codes, key cards, and mobile keys through a single request.
+     *
+     * @param array $requested_access_methods
+     * @param string $user_identity_id ID of user identity for whom access is being granted.
+     * @param mixed $user_identity When used, creates a new user identity with the given details, and grants them access.
+     * @param string $access_grant_key Unique key for the access grant within the workspace.
+     * @param array $acs_entrance_ids Set of IDs of the [entrances](https://docs.seam.co/api/acs/systems/list) to which access is being granted.
+     * @param string $customization_profile_id ID of the customization profile to apply to the Access Grant and its access methods.
+     * @param array $device_ids Set of IDs of the [devices](https://docs.seam.co/api/devices/list) to which access is being granted.
+     * @param string $ends_at Date and time at which the validity of the new grant ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+     * @param mixed $location
+     * @param array $location_ids
+     * @param string $name Name for the access grant.
+     * @param string $reservation_key Reservation key for the access grant.
+     * @param array $space_ids Set of IDs of existing spaces to which access is being granted.
+     * @param array $space_keys Set of keys of existing spaces to which access is being granted.
+     * @param string $starts_at Date and time at which the validity of the new grant starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @return AccessGrant OK
+     */
     public function create(
         array $requested_access_methods,
         ?string $user_identity_id = null,
@@ -933,6 +1185,12 @@ class AccessGrantsClient
         return AccessGrant::from_json($res->access_grant);
     }
 
+    /**
+     * Delete an Access Grant.
+     *
+     * @param string $access_grant_id ID of Access Grant to delete.
+     * @return void OK
+     */
     public function delete(string $access_grant_id): void
     {
         $request_payload = [];
@@ -948,6 +1206,13 @@ class AccessGrantsClient
         );
     }
 
+    /**
+     * Get an Access Grant.
+     *
+     * @param string $access_grant_id ID of Access Grant to get.
+     * @param string $access_grant_key Unique key of Access Grant to get.
+     * @return AccessGrant OK
+     */
     public function get(
         ?string $access_grant_id = null,
         ?string $access_grant_key = null,
@@ -970,6 +1235,15 @@ class AccessGrantsClient
         return AccessGrant::from_json($res->access_grant);
     }
 
+    /**
+     * Gets all related resources for one or more Access Grants.
+     *
+     * @param array $access_grant_ids IDs of the access grants that you want to get along with their related resources.
+     * @param array $access_grant_keys Keys of the access grants that you want to get along with their related resources.
+     * @param array $exclude
+     * @param array $include
+     * @return Batch OK
+     */
     public function get_related(
         ?array $access_grant_ids = null,
         ?array $access_grant_keys = null,
@@ -1000,6 +1274,24 @@ class AccessGrantsClient
         return Batch::from_json($res->batch);
     }
 
+    /**
+     * Gets an Access Grant.
+     *
+     * @param string $access_code_id ID of the access code by which you want to filter the list of Access Grants.
+     * @param array $access_grant_ids IDs of the access grants to retrieve.
+     * @param string $access_grant_key Filter Access Grants by access_grant_key. Use null to filter for Access Grants without an access_grant_key.
+     * @param string $acs_entrance_id ID of the entrance by which you want to filter the list of Access Grants.
+     * @param string $acs_system_id ID of the access system by which you want to filter the list of Access Grants.
+     * @param string $customer_key Customer key for which you want to list access grants.
+     * @param string $device_id ID of the device by which you want to filter the list of Access Grants.
+     * @param float $limit Numerical limit on the number of access grants to return.
+     * @param string $location_id
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $reservation_key Filter Access Grants by reservation_key.
+     * @param string $space_id ID of the space by which you want to filter the list of Access Grants.
+     * @param string $user_identity_id ID of user identity by which you want to filter the list of Access Grants.
+     * @return array OK
+     */
     public function list(
         ?string $access_code_id = null,
         ?array $access_grant_ids = null,
@@ -1074,6 +1366,13 @@ class AccessGrantsClient
         );
     }
 
+    /**
+     * Adds additional requested access methods to an existing Access Grant.
+     *
+     * @param string $access_grant_id ID of the Access Grant to add access methods to.
+     * @param array $requested_access_methods Array of requested access methods to add to the access grant.
+     * @return AccessGrant OK
+     */
     public function request_access_methods(
         string $access_grant_id,
         array $requested_access_methods,
@@ -1098,6 +1397,16 @@ class AccessGrantsClient
         return AccessGrant::from_json($res->access_grant);
     }
 
+    /**
+     * Updates an existing Access Grant's time window.
+     *
+     * @param string $access_grant_id ID of the Access Grant to update. Provide either `access_grant_id` or `access_grant_key`.
+     * @param string $access_grant_key Key of the Access Grant to update. Provide either `access_grant_id` or `access_grant_key`.
+     * @param string $ends_at Date and time at which the validity of the grant ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+     * @param string $name Display name for the access grant.
+     * @param string $starts_at Date and time at which the validity of the grant starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @return void OK
+     */
     public function update(
         ?string $access_grant_id = null,
         ?string $access_grant_key = null,
@@ -1140,6 +1449,12 @@ class AccessGrantsUnmanagedClient
         $this->seam = $seam;
     }
 
+    /**
+     * Get an unmanaged Access Grant (where is_managed = false).
+     *
+     * @param string $access_grant_id ID of unmanaged Access Grant to get.
+     * @return UnmanagedAccessGrant OK
+     */
     public function get(string $access_grant_id): UnmanagedAccessGrant
     {
         $request_payload = [];
@@ -1157,6 +1472,17 @@ class AccessGrantsUnmanagedClient
         return UnmanagedAccessGrant::from_json($res->access_grant);
     }
 
+    /**
+     * Gets unmanaged Access Grants (where is_managed = false).
+     *
+     * @param string $acs_entrance_id ID of the entrance by which you want to filter the list of unmanaged Access Grants.
+     * @param string $acs_system_id ID of the access system by which you want to filter the list of unmanaged Access Grants.
+     * @param float $limit Numerical limit on the number of unmanaged access grants to return.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $reservation_key Filter unmanaged Access Grants by reservation_key.
+     * @param string $user_identity_id ID of user identity by which you want to filter the list of unmanaged Access Grants.
+     * @return array OK
+     */
     public function list(
         ?string $acs_entrance_id = null,
         ?string $acs_system_id = null,
@@ -1203,6 +1529,18 @@ class AccessGrantsUnmanagedClient
         );
     }
 
+    /**
+     * Updates an unmanaged Access Grant to make it managed.
+     *
+     * This endpoint can only be used to convert unmanaged access grants to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed access grants back to unmanaged.
+     *
+     * When converting an unmanaged access grant to managed, all associated access methods will also be converted to managed.
+     *
+     * @param string $access_grant_id ID of the unmanaged Access Grant to update.
+     * @param bool $is_managed Must be set to true to convert the unmanaged access grant to managed.
+     * @param string $access_grant_key Unique key for the access grant. If not provided, the existing key will be preserved.
+     * @return void OK
+     */
     public function update(
         string $access_grant_id,
         bool $is_managed,
@@ -1238,6 +1576,13 @@ class AccessMethodsClient
         $this->unmanaged = new AccessMethodsUnmanagedClient($seam);
     }
 
+    /**
+     * Assigns a pre-registered card credential, identified by `card_number`, to a card-mode access method. Use this endpoint for access systems that use pre-registered cards, where a physical card must be associated with an access method before it can be used for access. Assigning a card credential also triggers issuance of the access method.
+     *
+     * @param string $access_method_id ID of the `access_method` to assign the credential to.
+     * @param string $card_number Card number of the credential to assign.
+     * @return ActionAttempt OK
+     */
     public function assign_card(
         string $access_method_id,
         string $card_number,
@@ -1269,6 +1614,14 @@ class AccessMethodsClient
         return $action_attempt;
     }
 
+    /**
+     * Deletes an access method.
+     *
+     * @param string $access_method_id ID of access method to delete.
+     * @param string $access_grant_id ID of access grant whose access methods should be deleted.
+     * @param string $reservation_key Reservation key of the access grant whose access methods should be deleted.
+     * @return void OK
+     */
     public function delete(
         ?string $access_method_id = null,
         ?string $access_grant_id = null,
@@ -1293,6 +1646,13 @@ class AccessMethodsClient
         );
     }
 
+    /**
+     * Encodes an existing access method onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+     *
+     * @param string $access_method_id ID of the `access_method` to encode onto a card.
+     * @param string $acs_encoder_id ID of the `acs_encoder` to use to encode the `access_method`.
+     * @return ActionAttempt OK
+     */
     public function encode(
         string $access_method_id,
         string $acs_encoder_id,
@@ -1324,6 +1684,12 @@ class AccessMethodsClient
         return $action_attempt;
     }
 
+    /**
+     * Gets an access method.
+     *
+     * @param string $access_method_id ID of access method to get.
+     * @return AccessMethod OK
+     */
     public function get(string $access_method_id): AccessMethod
     {
         $request_payload = [];
@@ -1341,6 +1707,14 @@ class AccessMethodsClient
         return AccessMethod::from_json($res->access_method);
     }
 
+    /**
+     * Gets all related resources for one or more Access Methods.
+     *
+     * @param array $access_method_ids IDs of the access methods that you want to get along with their related resources.
+     * @param array $exclude
+     * @param array $include
+     * @return Batch OK
+     */
     public function get_related(
         array $access_method_ids,
         ?array $exclude = null,
@@ -1367,6 +1741,19 @@ class AccessMethodsClient
         return Batch::from_json($res->batch);
     }
 
+    /**
+     * Lists all access methods, usually filtered by Access Grant.
+     *
+     * @param string $access_code_id ID of the access code by which to filter the returned access methods. Must be combined with `access_grant_id`, `access_grant_key`, or `acs_entrance_id`.
+     * @param string $access_grant_id ID of Access Grant to list access methods for.
+     * @param string $access_grant_key Key of Access Grant to list access methods for.
+     * @param string $acs_entrance_id ID of the entrance for which you want to retrieve all access methods that grant access to it.
+     * @param string $device_id ID of the device by which to filter the returned access methods. Must be combined with `access_grant_id`, `access_grant_key`, or `acs_entrance_id`.
+     * @param int $limit Maximum number of records to return per page.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $space_id ID of the space by which to filter the returned access methods. Must be combined with `access_grant_id`, `access_grant_key`, or `acs_entrance_id`.
+     * @return array OK
+     */
     public function list(
         ?string $access_code_id = null,
         ?string $access_grant_id = null,
@@ -1421,6 +1808,13 @@ class AccessMethodsClient
         );
     }
 
+    /**
+     * Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using the cloud key credential associated with an access method. Returns an action attempt that tracks the progress of the unlock operation.
+     *
+     * @param string $access_method_id ID of the cloud_key `access_method` to use for the unlock operation.
+     * @param string $acs_entrance_id ID of the entrance to unlock.
+     * @return ActionAttempt OK
+     */
     public function unlock_door(
         string $access_method_id,
         string $acs_entrance_id,
@@ -1462,6 +1856,12 @@ class AccessMethodsUnmanagedClient
         $this->seam = $seam;
     }
 
+    /**
+     * Gets an unmanaged access method (where is_managed = false).
+     *
+     * @param string $access_method_id ID of unmanaged access method to get.
+     * @return UnmanagedAccessMethod OK
+     */
     public function get(string $access_method_id): UnmanagedAccessMethod
     {
         $request_payload = [];
@@ -1479,6 +1879,15 @@ class AccessMethodsUnmanagedClient
         return UnmanagedAccessMethod::from_json($res->access_method);
     }
 
+    /**
+     * Lists all unmanaged access methods (where is_managed = false), usually filtered by Access Grant.
+     *
+     * @param string $access_grant_id ID of Access Grant to list unmanaged access methods for.
+     * @param string $acs_entrance_id ID of the entrance for which you want to retrieve all unmanaged access methods.
+     * @param string $device_id ID of the device for which you want to retrieve all unmanaged access methods.
+     * @param string $space_id ID of the space for which you want to retrieve all unmanaged access methods.
+     * @return array OK
+     */
     public function list(
         string $access_grant_id,
         ?string $acs_entrance_id = null,
@@ -1522,6 +1931,14 @@ class AcsAccessGroupsClient
         $this->seam = $seam;
     }
 
+    /**
+     * Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+     *
+     * @param string $acs_access_group_id ID of the access group to which you want to add an access system user.
+     * @param string $acs_user_id ID of the access system user that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id.
+     * @param string $user_identity_id ID of the desired user identity that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same `email_address` or `phone_number` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
+     * @return void OK
+     */
     public function add_user(
         string $acs_access_group_id,
         ?string $acs_user_id = null,
@@ -1546,6 +1963,12 @@ class AcsAccessGroupsClient
         );
     }
 
+    /**
+     * Deletes a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+     *
+     * @param string $acs_access_group_id ID of the access group that you want to delete.
+     * @return void OK
+     */
     public function delete(string $acs_access_group_id): void
     {
         $request_payload = [];
@@ -1561,6 +1984,12 @@ class AcsAccessGroupsClient
         );
     }
 
+    /**
+     * Returns a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+     *
+     * @param string $acs_access_group_id ID of the access group that you want to get.
+     * @return AcsAccessGroup OK
+     */
     public function get(string $acs_access_group_id): AcsAccessGroup
     {
         $request_payload = [];
@@ -1578,6 +2007,15 @@ class AcsAccessGroupsClient
         return AcsAccessGroup::from_json($res->acs_access_group);
     }
 
+    /**
+     * Returns a list of all [access groups](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+     *
+     * @param string $acs_system_id ID of the access system for which you want to retrieve all access groups.
+     * @param string $acs_user_id ID of the access system user for which you want to retrieve all access groups.
+     * @param string $search String for which to search. Filters returned access groups to include all records that satisfy a partial match using `name` or `acs_access_group_id`.
+     * @param string $user_identity_id ID of the user identity for which you want to retrieve all access groups.
+     * @return array OK
+     */
     public function list(
         ?string $acs_system_id = null,
         ?string $acs_user_id = null,
@@ -1611,6 +2049,12 @@ class AcsAccessGroupsClient
         );
     }
 
+    /**
+     * Returns a list of all accessible entrances for a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+     *
+     * @param string $acs_access_group_id ID of the access group for which you want to retrieve all accessible entrances.
+     * @return array OK
+     */
     public function list_accessible_entrances(
         string $acs_access_group_id,
     ): array {
@@ -1632,6 +2076,12 @@ class AcsAccessGroupsClient
         );
     }
 
+    /**
+     * Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+     *
+     * @param string $acs_access_group_id ID of the access group for which you want to retrieve all access system users.
+     * @return array OK
+     */
     public function list_users(string $acs_access_group_id): array
     {
         $request_payload = [];
@@ -1649,6 +2099,14 @@ class AcsAccessGroupsClient
         return array_map(fn($r) => AcsUser::from_json($r), $res->acs_users);
     }
 
+    /**
+     * Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+     *
+     * @param string $acs_access_group_id ID of the access group from which you want to remove an access system user.
+     * @param string $acs_user_id ID of the access system user that you want to remove from an access group.
+     * @param string $user_identity_id ID of the user identity associated with the user that you want to remove from an access group.
+     * @return void OK
+     */
     public function remove_user(
         string $acs_access_group_id,
         ?string $acs_user_id = null,
@@ -1704,6 +2162,14 @@ class AcsCredentialsClient
         $this->seam = $seam;
     }
 
+    /**
+     * Assigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) to a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     *
+     * @param string $acs_credential_id ID of the credential that you want to assign to an access system user.
+     * @param string $acs_user_id ID of the access system user to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id.
+     * @param string $user_identity_id ID of the user identity to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same `email_address` or `phone_number` as the user identity that you specify, they are linked, and the credential belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
+     * @return void OK
+     */
     public function assign(
         string $acs_credential_id,
         ?string $acs_user_id = null,
@@ -1728,6 +2194,24 @@ class AcsCredentialsClient
         );
     }
 
+    /**
+     * Creates a new [credential](https://docs.seam.co/low-level-apis/managing-credentials) for a specified [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they create and manage the underlying credentials for you, across access systems and standalone smart locks alike. Use this low-level endpoint only when you need direct control over an individual ACS credential.
+     *
+     * @param string $access_method Access method for the new credential. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+     * @param string $acs_system_id ID of the access system to which the new credential belongs. You must provide either `acs_user_id` or the combination of `user_identity_id` and `acs_system_id`.
+     * @param string $acs_user_id ID of the access system user to whom the new credential belongs. You must provide either `acs_user_id` or the combination of `user_identity_id` and `acs_system_id`.
+     * @param array $allowed_acs_entrance_ids Set of IDs of the [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for which the new credential grants access.
+     * @param mixed $assa_abloy_vostio_metadata Vostio-specific metadata for the new credential.
+     * @param string $code Access (PIN) code for the new credential. There may be manufacturer-specific code restrictions. For details, see the applicable [device or system integration guide](https://docs.seam.co/device-and-system-integration-guides).
+     * @param string $credential_manager_acs_system_id ACS system ID of the credential manager for the new credential.
+     * @param string $ends_at Date and time at which the validity of the new credential ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+     * @param bool $is_multi_phone_sync_credential Indicates whether the new credential is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+     * @param mixed $salto_space_metadata Salto Space-specific metadata for the new credential.
+     * @param string $starts_at Date and time at which the validity of the new credential starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @param string $user_identity_id ID of the user identity to whom the new credential belongs. You must provide either `acs_user_id` or the combination of `user_identity_id` and `acs_system_id`. If the access system contains a user with the same `email_address` or `phone_number` as the user identity that you specify, they are linked, and the credential belongs to the access system user. If the access system does not have a corresponding user, one is created.
+     * @param mixed $visionline_metadata Visionline-specific metadata for the new credential.
+     * @return AcsCredential OK
+     */
     public function create(
         string $access_method,
         ?string $acs_system_id = null,
@@ -1802,6 +2286,12 @@ class AcsCredentialsClient
         return AcsCredential::from_json($res->acs_credential);
     }
 
+    /**
+     * Deletes a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+     *
+     * @param string $acs_credential_id ID of the credential that you want to delete.
+     * @return void OK
+     */
     public function delete(string $acs_credential_id): void
     {
         $request_payload = [];
@@ -1817,6 +2307,12 @@ class AcsCredentialsClient
         );
     }
 
+    /**
+     * Returns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+     *
+     * @param string $acs_credential_id ID of the credential that you want to get.
+     * @return AcsCredential OK
+     */
     public function get(string $acs_credential_id): AcsCredential
     {
         $request_payload = [];
@@ -1834,6 +2330,19 @@ class AcsCredentialsClient
         return AcsCredential::from_json($res->acs_credential);
     }
 
+    /**
+     * Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+     *
+     * @param string $acs_user_id ID of the access system user for which you want to retrieve all credentials.
+     * @param string $acs_system_id ID of the access system for which you want to retrieve all credentials.
+     * @param string $user_identity_id ID of the user identity for which you want to retrieve all credentials.
+     * @param string $created_before Date and time, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, before which events to return were created.
+     * @param bool $is_multi_phone_sync_credential Indicates whether you want to retrieve only multi-phone sync credentials or non-multi-phone sync credentials.
+     * @param float $limit Number of credentials to return.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned credentials to include all records that satisfy a partial match using `display_name`, `code`, `card_number`, `acs_user_id` or `acs_credential_id`.
+     * @return array OK
+     */
     public function list(
         ?string $acs_user_id = null,
         ?string $acs_system_id = null,
@@ -1890,6 +2399,12 @@ class AcsCredentialsClient
         );
     }
 
+    /**
+     * Returns a list of all [entrances](https://docs.seam.co/api/acs/entrances) to which a [credential](https://docs.seam.co/api/acs/credentials) grants access.
+     *
+     * @param string $acs_credential_id ID of the credential for which you want to retrieve all entrances to which the credential grants access.
+     * @return array OK
+     */
     public function list_accessible_entrances(string $acs_credential_id): array
     {
         $request_payload = [];
@@ -1910,6 +2425,14 @@ class AcsCredentialsClient
         );
     }
 
+    /**
+     * Unassigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     *
+     * @param string $acs_credential_id ID of the credential that you want to unassign from an access system user.
+     * @param string $acs_user_id ID of the access system user from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
+     * @param string $user_identity_id ID of the user identity from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
+     * @return void OK
+     */
     public function unassign(
         string $acs_credential_id,
         ?string $acs_user_id = null,
@@ -1934,6 +2457,14 @@ class AcsCredentialsClient
         );
     }
 
+    /**
+     * Updates the code and ends at date and time for a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+     *
+     * @param string $acs_credential_id ID of the credential that you want to update.
+     * @param string $code Replacement access (PIN) code for the credential that you want to update.
+     * @param string $ends_at Replacement date and time at which the validity of the credential ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after the `starts_at` value that you set when creating the credential.
+     * @return void OK
+     */
     public function update(
         string $acs_credential_id,
         ?string $code = null,
@@ -1969,6 +2500,14 @@ class AcsEncodersClient
         $this->simulate = new AcsEncodersSimulateClient($seam);
     }
 
+    /**
+     * Encodes an existing [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners). Either provide an `acs_credential_id` or an `access_method_id`
+     *
+     * @param string $acs_encoder_id ID of the `acs_encoder` to use to encode the `acs_credential`.
+     * @param string $access_method_id ID of the `access_method` to encode onto a card.
+     * @param string $acs_credential_id ID of the `acs_credential` to encode onto a card.
+     * @return ActionAttempt OK
+     */
     public function encode_credential(
         string $acs_encoder_id,
         ?string $access_method_id = null,
@@ -2004,6 +2543,12 @@ class AcsEncodersClient
         return $action_attempt;
     }
 
+    /**
+     * Returns a specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+     *
+     * @param string $acs_encoder_id ID of the encoder that you want to get.
+     * @return AcsEncoder OK
+     */
     public function get(string $acs_encoder_id): AcsEncoder
     {
         $request_payload = [];
@@ -2021,6 +2566,16 @@ class AcsEncodersClient
         return AcsEncoder::from_json($res->acs_encoder);
     }
 
+    /**
+     * Returns a list of all [encoders](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+     *
+     * @param string $acs_system_id ID of the access system for which you want to retrieve all encoders.
+     * @param array $acs_system_ids IDs of the access systems for which you want to retrieve all encoders.
+     * @param array $acs_encoder_ids IDs of the encoders that you want to retrieve.
+     * @param float $limit Number of encoders to return.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @return array OK
+     */
     public function list(
         ?string $acs_system_id = null,
         ?array $acs_system_ids = null,
@@ -2063,6 +2618,13 @@ class AcsEncodersClient
         );
     }
 
+    /**
+     * Scans an encoded [acs_credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+     *
+     * @param string $acs_encoder_id ID of the encoder to use for the scan.
+     * @param mixed $salto_ks_metadata Salto KS-specific metadata for the scan action.
+     * @return ActionAttempt OK
+     */
     public function scan_credential(
         string $acs_encoder_id,
         mixed $salto_ks_metadata = null,
@@ -2094,6 +2656,15 @@ class AcsEncodersClient
         return $action_attempt;
     }
 
+    /**
+     * Scans a physical card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) and assigns the scanned credential to an ACS user. Provide either an `acs_user_id` or a `user_identity_id`.
+     *
+     * @param string $acs_encoder_id ID of the `acs_encoder` to use to scan the credential.
+     * @param string $acs_user_id ID of the `acs_user` to assign the scanned credential to.
+     * @param mixed $salto_ks_metadata Salto KS-specific metadata for the scan action.
+     * @param string $user_identity_id ID of the `user_identity` to assign the scanned credential to. If the ACS system contains an ACS user linked to this user identity, it is used. Otherwise, one is created.
+     * @return ActionAttempt OK
+     */
     public function scan_to_assign_credential(
         string $acs_encoder_id,
         ?string $acs_user_id = null,
@@ -2143,6 +2714,14 @@ class AcsEncodersSimulateClient
         $this->seam = $seam;
     }
 
+    /**
+     * Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     *
+     * @param string $acs_encoder_id ID of the `acs_encoder` that will be used in the next request to encode the `acs_credential`.
+     * @param string $error_code Code of the error to simulate.
+     * @param string $acs_credential_id ID of the `acs_credential` that will fail to be encoded onto a card in the next request.
+     * @return void OK
+     */
     public function next_credential_encode_will_fail(
         string $acs_encoder_id,
         ?string $error_code = null,
@@ -2167,6 +2746,13 @@ class AcsEncodersSimulateClient
         );
     }
 
+    /**
+     * Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     *
+     * @param string $acs_encoder_id ID of the `acs_encoder` that will be used in the next request to encode the `acs_credential`.
+     * @param string $scenario Scenario to simulate.
+     * @return void OK
+     */
     public function next_credential_encode_will_succeed(
         string $acs_encoder_id,
         ?string $scenario = null,
@@ -2187,6 +2773,14 @@ class AcsEncodersSimulateClient
         );
     }
 
+    /**
+     * Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     *
+     * @param string $acs_encoder_id ID of the `acs_encoder` that will fail to scan the `acs_credential` in the next request.
+     * @param string $error_code
+     * @param string $acs_credential_id_on_seam
+     * @return void OK
+     */
     public function next_credential_scan_will_fail(
         string $acs_encoder_id,
         ?string $error_code = null,
@@ -2213,6 +2807,14 @@ class AcsEncodersSimulateClient
         );
     }
 
+    /**
+     * Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     *
+     * @param string $acs_encoder_id ID of the `acs_encoder` that will be used in the next request to scan the `acs_credential`.
+     * @param string $acs_credential_id_on_seam ID of the Seam `acs_credential` that matches the `acs_credential` on the encoder in this simulation.
+     * @param string $scenario Scenario to simulate.
+     * @return void OK
+     */
     public function next_credential_scan_will_succeed(
         string $acs_encoder_id,
         ?string $acs_credential_id_on_seam = null,
@@ -2249,6 +2851,12 @@ class AcsEntrancesClient
         $this->seam = $seam;
     }
 
+    /**
+     * Returns a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+     *
+     * @param string $acs_entrance_id ID of the entrance that you want to get.
+     * @return AcsEntrance OK
+     */
     public function get(string $acs_entrance_id): AcsEntrance
     {
         $request_payload = [];
@@ -2266,6 +2874,14 @@ class AcsEntrancesClient
         return AcsEntrance::from_json($res->acs_entrance);
     }
 
+    /**
+     * Grants a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) access to a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+     *
+     * @param string $acs_entrance_id ID of the entrance to which you want to grant an access system user access.
+     * @param string $acs_user_id ID of the access system user to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id.
+     * @param string $user_identity_id ID of the user identity to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same `email_address` or `phone_number` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
+     * @return void OK
+     */
     public function grant_access(
         string $acs_entrance_id,
         ?string $acs_user_id = null,
@@ -2290,6 +2906,22 @@ class AcsEntrancesClient
         );
     }
 
+    /**
+     * Returns a list of all [access system entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+     *
+     * @param string $access_method_id ID of the access method for which you want to retrieve all entrances to which it grants access.
+     * @param string $acs_credential_id ID of the credential for which you want to retrieve all entrances.
+     * @param array $acs_entrance_ids IDs of the entrances for which you want to retrieve all entrances.
+     * @param string $acs_system_id ID of the access system for which you want to retrieve all entrances.
+     * @param string $connected_account_id ID of the connected account for which you want to retrieve all entrances.
+     * @param string $customer_key Customer key for which you want to list entrances.
+     * @param int $limit Maximum number of records to return per page.
+     * @param string $location_id
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned entrances to include all records that satisfy a partial match using `display_name`.
+     * @param string $space_id ID of the space for which you want to list entrances.
+     * @return array OK
+     */
     public function list(
         ?string $access_method_id = null,
         ?string $acs_credential_id = null,
@@ -2356,6 +2988,13 @@ class AcsEntrancesClient
         );
     }
 
+    /**
+     * Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) with access to a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+     *
+     * @param string $acs_entrance_id ID of the entrance for which you want to list all credentials that grant access.
+     * @param array $include_if Conditions that credentials must meet to be included in the returned list.
+     * @return array OK
+     */
     public function list_credentials_with_access(
         string $acs_entrance_id,
         ?array $include_if = null,
@@ -2381,6 +3020,13 @@ class AcsEntrancesClient
         );
     }
 
+    /**
+     * Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using a cloud_key credential. Returns an action attempt that tracks the progress of the unlock operation.
+     *
+     * @param string $acs_credential_id ID of the cloud_key credential to use for the unlock operation.
+     * @param string $acs_entrance_id ID of the entrance to unlock.
+     * @return ActionAttempt OK
+     */
     public function unlock(
         string $acs_credential_id,
         string $acs_entrance_id,
@@ -2422,6 +3068,12 @@ class AcsSystemsClient
         $this->seam = $seam;
     }
 
+    /**
+     * Returns a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+     *
+     * @param string $acs_system_id ID of the access system that you want to get.
+     * @return AcsSystem OK
+     */
     public function get(string $acs_system_id): AcsSystem
     {
         $request_payload = [];
@@ -2439,6 +3091,16 @@ class AcsSystemsClient
         return AcsSystem::from_json($res->acs_system);
     }
 
+    /**
+     * Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems).
+     *
+     * To filter the list of returned access systems by a specific connected account ID, include the `connected_account_id` in the request body. If you omit the `connected_account_id` parameter, the response includes all access systems connected to your workspace.
+     *
+     * @param string $connected_account_id ID of the connected account by which you want to filter the list of access systems.
+     * @param string $customer_key Customer key for which you want to list access systems.
+     * @param string $search String for which to search. Filters returned access systems to include all records that satisfy a partial match using `name` or `acs_system_id`.
+     * @return array OK
+     */
     public function list(
         ?string $connected_account_id = null,
         ?string $customer_key = null,
@@ -2465,6 +3127,14 @@ class AcsSystemsClient
         return array_map(fn($r) => AcsSystem::from_json($r), $res->acs_systems);
     }
 
+    /**
+     * Returns a list of all credential manager systems that are compatible with a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+     *
+     * Specify the access system for which you want to retrieve all compatible credential manager systems by including the corresponding `acs_system_id` in the request body.
+     *
+     * @param string $acs_system_id ID of the access system for which you want to retrieve all compatible credential manager systems.
+     * @return array OK
+     */
     public function list_compatible_credential_manager_acs_systems(
         string $acs_system_id,
     ): array {
@@ -2483,6 +3153,14 @@ class AcsSystemsClient
         return array_map(fn($r) => AcsSystem::from_json($r), $res->acs_systems);
     }
 
+    /**
+     * Reports ACS system device status including encoders and entrances.
+     *
+     * @param string $acs_system_id ID of the ACS system to report resources for
+     * @param array $acs_encoders Array of ACS encoders to report
+     * @param array $acs_entrances Array of ACS entrances to report
+     * @return void OK
+     */
     public function report_devices(
         string $acs_system_id,
         ?array $acs_encoders = null,
@@ -2517,6 +3195,13 @@ class AcsUsersClient
         $this->seam = $seam;
     }
 
+    /**
+     * Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+     *
+     * @param string $acs_access_group_id ID of the access group to which you want to add an access system user.
+     * @param string $acs_user_id ID of the access system user that you want to add to an access group.
+     * @return void OK
+     */
     public function add_to_access_group(
         string $acs_access_group_id,
         string $acs_user_id,
@@ -2537,6 +3222,19 @@ class AcsUsersClient
         );
     }
 
+    /**
+     * Creates a new [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     *
+     * @param string $acs_system_id ID of the access system to which you want to add the new access system user.
+     * @param string $full_name Full name of the new access system user.
+     * @param mixed $access_schedule `starts_at` and `ends_at` timestamps for the new access system user's access. If you specify an `access_schedule`, you may include both `starts_at` and `ends_at`. If you omit `starts_at`, it defaults to the current time. `ends_at` is optional and must be a time in the future and after `starts_at`.
+     * @param array $acs_access_group_ids Array of access group IDs to indicate the access groups to which you want to add the new access system user.
+     * @param string $email
+     * @param string $email_address Email address of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     * @param string $phone_number Phone number of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
+     * @param string $user_identity_id ID of the user identity with which you want to associate the new access system user.
+     * @return AcsUser OK
+     */
     public function create(
         string $acs_system_id,
         string $full_name,
@@ -2583,6 +3281,14 @@ class AcsUsersClient
         return AcsUser::from_json($res->acs_user);
     }
 
+    /**
+     * Deletes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) and invalidates the access system user's [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+     *
+     * @param string $acs_system_id ID of the access system that you want to delete. You must provide acs_system_id with user_identity_id.
+     * @param string $acs_user_id ID of the access system user that you want to delete. You must provide either acs_user_id or user_identity_id
+     * @param string $user_identity_id ID of the user identity that you want to delete. You must provide either acs_user_id or user_identity_id. If you provide user_identity_id, you must also provide acs_system_id.
+     * @return void OK
+     */
     public function delete(
         ?string $acs_system_id = null,
         ?string $acs_user_id = null,
@@ -2607,6 +3313,14 @@ class AcsUsersClient
         );
     }
 
+    /**
+     * Returns a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     *
+     * @param string $acs_user_id ID of the access system user that you want to get. You can only provide acs_user_id or user_identity_id.
+     * @param string $acs_system_id ID of the access system that you want to get. You can only provide acs_user_id or user_identity_id.
+     * @param string $user_identity_id ID of the user identity that you want to get. You can only provide acs_user_id or user_identity_id.
+     * @return AcsUser OK
+     */
     public function get(
         ?string $acs_user_id = null,
         ?string $acs_system_id = null,
@@ -2633,6 +3347,19 @@ class AcsUsersClient
         return AcsUser::from_json($res->acs_user);
     }
 
+    /**
+     * Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     *
+     * @param string $acs_system_id ID of the `acs_system` for which you want to retrieve all access system users.
+     * @param string $created_before Timestamp by which to limit returned access system users. Returns users created before this timestamp.
+     * @param int $limit Maximum number of records to return per page.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned access system users to include all records that satisfy a partial match using `full_name`, `phone_number`, `email_address`, `acs_user_id`, `user_identity_id`, `user_identity_full_name` or `user_identity_phone_number`.
+     * @param string $user_identity_email_address Email address of the user identity for which you want to retrieve all access system users.
+     * @param string $user_identity_id ID of the user identity for which you want to retrieve all access system users.
+     * @param string $user_identity_phone_number Phone number of the user identity for which you want to retrieve all access system users, in [E.164 format](https://www.itu.int/rec/T-REC-E.164/en) (for example, `+15555550100`).
+     * @return array OK
+     */
     public function list(
         ?string $acs_system_id = null,
         ?string $created_before = null,
@@ -2688,6 +3415,14 @@ class AcsUsersClient
         return array_map(fn($r) => AcsUser::from_json($r), $res->acs_users);
     }
 
+    /**
+     * Lists the [entrances](https://docs.seam.co/api/acs/entrances) to which a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) has access.
+     *
+     * @param string $acs_system_id ID of the access system for which you want to list accessible entrances. You can only provide acs_system_id with user_identity_id.
+     * @param string $acs_user_id ID of the access system user for whom you want to list accessible entrances. You can only provide acs_user_id or user_identity_id.
+     * @param string $user_identity_id ID of the user identity for whom you want to list accessible entrances. You can only provide acs_user_id or user_identity_id.
+     * @return array OK
+     */
     public function list_accessible_entrances(
         ?string $acs_system_id = null,
         ?string $acs_user_id = null,
@@ -2717,6 +3452,14 @@ class AcsUsersClient
         );
     }
 
+    /**
+     * Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+     *
+     * @param string $acs_access_group_id ID of the access group from which you want to remove an access system user.
+     * @param string $acs_user_id ID of the access system user that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
+     * @param string $user_identity_id ID of the user identity that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
+     * @return void OK
+     */
     public function remove_from_access_group(
         string $acs_access_group_id,
         ?string $acs_user_id = null,
@@ -2741,6 +3484,14 @@ class AcsUsersClient
         );
     }
 
+    /**
+     * Revokes access to all [entrances](https://docs.seam.co/api/acs/entrances) for a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     *
+     * @param string $acs_system_id ID of the access system for which you want to revoke access. You can only provide acs_system_id with user_identity_id.
+     * @param string $acs_user_id ID of the access system user for whom you want to revoke access. You can only provide acs_user_id or user_identity_id.
+     * @param string $user_identity_id ID of the user identity for whom you want to revoke access. You can only provide acs_user_id or user_identity_id.
+     * @return void OK
+     */
     public function revoke_access_to_all_entrances(
         ?string $acs_system_id = null,
         ?string $acs_user_id = null,
@@ -2765,6 +3516,14 @@ class AcsUsersClient
         );
     }
 
+    /**
+     * [Suspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#suspend-an-acs-user) a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). Suspending an access system user revokes their access temporarily. To restore an access system user's access, you can [unsuspend](https://docs.seam.co/api/acs/users/unsuspend) them.
+     *
+     * @param string $acs_system_id ID of the access system that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     * @param string $acs_user_id ID of the access system user that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     * @param string $user_identity_id ID of the user identity that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     * @return void OK
+     */
     public function suspend(
         ?string $acs_system_id = null,
         ?string $acs_user_id = null,
@@ -2789,6 +3548,14 @@ class AcsUsersClient
         );
     }
 
+    /**
+     * [Unsuspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#unsuspend-an-acs-user) a specified suspended [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). While [suspending an access system user](https://docs.seam.co/api/acs/users/suspend) revokes their access temporarily, unsuspending the access system user restores their access.
+     *
+     * @param string $acs_system_id ID of the access system of the user that you want to unsuspend. You can only provide acs_system_id with user_identity_id.
+     * @param string $acs_user_id ID of the access system user that you want to unsuspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     * @param string $user_identity_id ID of the user identity that you want to unsuspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+     * @return void OK
+     */
     public function unsuspend(
         ?string $acs_system_id = null,
         ?string $acs_user_id = null,
@@ -2813,6 +3580,20 @@ class AcsUsersClient
         );
     }
 
+    /**
+     * Updates the properties of a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     *
+     * @param mixed $access_schedule `starts_at` and `ends_at` timestamps for the access system user's access. If you specify an `access_schedule`, you may include both `starts_at` and `ends_at`. If you omit `starts_at`, it defaults to the current time. `ends_at` is optional and must be a time in the future and after `starts_at`.
+     * @param string $acs_system_id ID of the access system that you want to update. You can only provide acs_system_id with user_identity_id.
+     * @param string $acs_user_id ID of the access system user that you want to update. You can only provide acs_user_id or user_identity_id.
+     * @param string $email
+     * @param string $email_address Email address of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     * @param string $full_name Full name of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+     * @param string $hid_acs_system_id ID of the HID access control system associated with the user.
+     * @param string $phone_number Phone number of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
+     * @param string $user_identity_id ID of the user identity that you want to update. You can only provide acs_user_id or user_identity_id. If you provide user_identity_id, you must also provide acs_system_id.
+     * @return void OK
+     */
     public function update(
         mixed $access_schedule = null,
         ?string $acs_system_id = null,
@@ -2871,6 +3652,12 @@ class ActionAttemptsClient
         $this->seam = $seam;
     }
 
+    /**
+     * Returns a specified [action attempt](https://docs.seam.co/core-concepts/action-attempts).
+     *
+     * @param string $action_attempt_id ID of the action attempt that you want to get.
+     * @return ActionAttempt OK
+     */
     public function get(string $action_attempt_id): ActionAttempt
     {
         $request_payload = [];
@@ -2888,6 +3675,15 @@ class ActionAttemptsClient
         return ActionAttempt::from_json($res->action_attempt);
     }
 
+    /**
+     * Returns a list of the [action attempts](https://docs.seam.co/core-concepts/action-attempts) that you specify as an array of `action_attempt_id`s.
+     *
+     * @param array $action_attempt_ids IDs of the action attempts that you want to retrieve.
+     * @param string $device_id ID of the device to filter action attempts by.
+     * @param int $limit Maximum number of records to return per page.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @return array OK
+     */
     public function list(
         ?array $action_attempt_ids = null,
         ?string $device_id = null,
@@ -2962,6 +3758,19 @@ class ClientSessionsClient
         $this->seam = $seam;
     }
 
+    /**
+     * Creates a new [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+     *
+     * @param array $connect_webview_ids IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) for which you want to create a client session.
+     * @param array $connected_account_ids IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) for which you want to create a client session.
+     * @param string $customer_id Customer ID that you want to associate with the new client session.
+     * @param string $customer_key Customer key that you want to associate with the new client session.
+     * @param string $expires_at Date and time at which the client session should expire, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @param string $user_identifier_key Your user ID for the user for whom you want to create a client session.
+     * @param string $user_identity_id ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to create a client session.
+     * @param array $user_identity_ids IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+     * @return ClientSession OK
+     */
     public function create(
         ?array $connect_webview_ids = null,
         ?array $connected_account_ids = null,
@@ -3008,6 +3817,12 @@ class ClientSessionsClient
         return ClientSession::from_json($res->client_session);
     }
 
+    /**
+     * Deletes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+     *
+     * @param string $client_session_id ID of the client session that you want to delete.
+     * @return void OK
+     */
     public function delete(string $client_session_id): void
     {
         $request_payload = [];
@@ -3023,6 +3838,13 @@ class ClientSessionsClient
         );
     }
 
+    /**
+     * Returns a specified [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+     *
+     * @param string $client_session_id ID of the client session that you want to get.
+     * @param string $user_identifier_key User identifier key associated with the client session that you want to get.
+     * @return ClientSession OK
+     */
     public function get(
         ?string $client_session_id = null,
         ?string $user_identifier_key = null,
@@ -3045,6 +3867,17 @@ class ClientSessionsClient
         return ClientSession::from_json($res->client_session);
     }
 
+    /**
+     * Returns a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) with specific characteristics or creates a new client session with these characteristics if it does not yet exist.
+     *
+     * @param array $connect_webview_ids IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) that you want to associate with the client session (or that are already associated with the existing client session).
+     * @param array $connected_account_ids IDs of the [connected accounts](https://docs.seam.co/api/connected_accounts) that you want to associate with the client session (or that are already associated with the existing client session).
+     * @param string $expires_at Date and time at which the client session should expire in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. If the client session already exists, this will update the expiration before returning it.
+     * @param string $user_identifier_key Your user ID for the user that you want to associate with the client session (or that is already associated with the existing client session).
+     * @param string $user_identity_id ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session (or that are already associated with the existing client session).
+     * @param array $user_identity_ids IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+     * @return ClientSession OK
+     */
     public function get_or_create(
         ?array $connect_webview_ids = null,
         ?array $connected_account_ids = null,
@@ -3083,6 +3916,17 @@ class ClientSessionsClient
         return ClientSession::from_json($res->client_session);
     }
 
+    /**
+     * Grants a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) access to one or more resources, such as [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews), [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity), and so on.
+     *
+     * @param string $client_session_id ID of the client session to which you want to grant access to resources.
+     * @param array $connect_webview_ids IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) that you want to associate with the client session.
+     * @param array $connected_account_ids IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) that you want to associate with the client session.
+     * @param string $user_identifier_key Your user ID for the user that you want to associate with the client session.
+     * @param string $user_identity_id ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+     * @param array $user_identity_ids IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+     * @return void OK
+     */
     public function grant_access(
         ?string $client_session_id = null,
         ?array $connect_webview_ids = null,
@@ -3119,6 +3963,16 @@ class ClientSessionsClient
         );
     }
 
+    /**
+     * Returns a list of all [client sessions](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+     *
+     * @param string $client_session_id ID of the client session that you want to retrieve.
+     * @param string $connect_webview_id ID of the [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) for which you want to retrieve client sessions.
+     * @param string $user_identifier_key Your user ID for the user by which you want to filter client sessions.
+     * @param string $user_identity_id ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to retrieve client sessions.
+     * @param bool $without_user_identifier_key Indicates whether to retrieve only client sessions without associated user identifier keys.
+     * @return array OK
+     */
     public function list(
         ?string $client_session_id = null,
         ?string $connect_webview_id = null,
@@ -3158,6 +4012,14 @@ class ClientSessionsClient
         );
     }
 
+    /**
+     * Revokes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+     *
+     * Note that [deleting a client session](https://docs.seam.co/api/client_sessions/delete) is a separate action.
+     *
+     * @param string $client_session_id ID of the client session that you want to revoke.
+     * @return void OK
+     */
     public function revoke(string $client_session_id): void
     {
         $request_payload = [];
@@ -3183,6 +4045,27 @@ class ConnectWebviewsClient
         $this->seam = $seam;
     }
 
+    /**
+     * Creates a new [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+     *
+     * To enable a user to connect their devices or systems to Seam, they must sign in to their device or system account. To enable a user to sign in, you create a `connect_webview`. After creating the Connect Webview, you receive a URL that you can use to display the visual component of this Connect Webview for your user. You can open an iframe or new window to display the Connect Webview.
+     *
+     * You should make a new `connect_webview` for each unique login request. Each `connect_webview` tracks the user that signed in with it. You receive an error if you reuse a Connect Webview for the same user twice or if you use the same Connect Webview for multiple users.
+     *
+     * See also: [Connect Webview Process](https://docs.seam.co/core-concepts/connect-webviews/connect-webview-process).
+     *
+     * @param array $accepted_capabilities List of accepted device capabilities that restrict the types of devices that can be connected through the Connect Webview. If not provided, defaults will be determined based on the accepted providers.
+     * @param array $accepted_providers Accepted device provider keys as an alternative to `provider_category`. Use this parameter to specify accepted providers explicitly. See [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews). To list all provider keys, use [`/devices/list_device_providers`](https://docs.seam.co/api/devices/list_device_providers) with no filters.
+     * @param bool $automatically_manage_new_devices Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). See also: [Customize the Behavior Settings of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-behavior-settings-of-your-connect-webviews).
+     * @param mixed $custom_metadata Custom metadata that you want to associate with the Connect Webview. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview) enables you to store custom information, like customer details or internal IDs from your application. The custom metadata is then transferred to any [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) that were connected using the Connect Webview, making it easy to find and filter these resources in your [workspace](https://docs.seam.co/core-concepts/workspaces). You can also [filter Connect Webviews by custom metadata](https://docs.seam.co/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata).
+     * @param string $custom_redirect_failure_url Alternative URL that you want to redirect the user to on an error. If you do not set this parameter, the Connect Webview falls back to the `custom_redirect_url`.
+     * @param string $custom_redirect_url URL that you want to redirect the user to after the provider login is complete.
+     * @param string $customer_key Associate the Connect Webview, the connected account, and all resources under the connected account with a customer. If the connected account already exists, it will be associated with the customer. If the connected account already exists, but is already associated with a customer, the Connect Webview will show an error.
+     * @param array $excluded_providers List of provider keys to exclude from the Connect Webview. These providers will not be shown when the user tries to connect an account.
+     * @param string $provider_category Specifies the category of providers that you want to include. To list all providers within a category, use [`/devices/list_device_providers`](https://docs.seam.co/api/devices/list_device_providers) with the desired `provider_category` filter.
+     * @param bool $wait_for_device_creation Indicates whether Seam should finish syncing all devices in a newly-connected account before completing the associated Connect Webview. See also: [Customize the Behavior Settings of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-behavior-settings-of-your-connect-webviews).
+     * @return ConnectWebview OK
+     */
     public function create(
         ?array $accepted_capabilities = null,
         ?array $accepted_providers = null,
@@ -3243,6 +4126,14 @@ class ConnectWebviewsClient
         return ConnectWebview::from_json($res->connect_webview);
     }
 
+    /**
+     * Deletes a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+     *
+     * You do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.
+     *
+     * @param string $connect_webview_id ID of the Connect Webview that you want to delete.
+     * @return void OK
+     */
     public function delete(string $connect_webview_id): void
     {
         $request_payload = [];
@@ -3258,6 +4149,14 @@ class ConnectWebviewsClient
         );
     }
 
+    /**
+     * Returns a specified [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+     *
+     * Unless you're using a `custom_redirect_url`, you should poll a newly-created `connect_webview` to find out if the user has signed in or to get details about what devices they've connected.
+     *
+     * @param string $connect_webview_id ID of the Connect Webview that you want to get.
+     * @return ConnectWebview OK
+     */
     public function get(string $connect_webview_id): ConnectWebview
     {
         $request_payload = [];
@@ -3275,6 +4174,17 @@ class ConnectWebviewsClient
         return ConnectWebview::from_json($res->connect_webview);
     }
 
+    /**
+     * Returns a list of all [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews).
+     *
+     * @param mixed $custom_metadata_has Custom metadata pairs by which you want to [filter Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata). Returns Connect Webviews with `custom_metadata` that contains all of the provided key:value pairs.
+     * @param string $customer_key Customer key for which you want to list connect webviews.
+     * @param float $limit Maximum number of records to return per page.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned Connect Webviews to include all records that satisfy a partial match using `connect_webview_id`, `accepted_providers`, `custom_metadata`, or `customer_key`.
+     * @param string $user_identifier_key Your user ID for the user by which you want to filter Connect Webviews.
+     * @return array OK
+     */
     public function list(
         mixed $custom_metadata_has = null,
         ?string $customer_key = null,
@@ -3332,6 +4242,16 @@ class ConnectedAccountsClient
         $this->simulate = new ConnectedAccountsSimulateClient($seam);
     }
 
+    /**
+     * Deletes a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+     *
+     * Deleting a connected account triggers a `connected_account.deleted` event and removes the connected account and all data associated with the connected account from Seam, including devices, events, access codes, and so on. For every deleted resource, Seam sends a corresponding deleted event, but the resource is not deleted from the provider.
+     *
+     * For example, if you delete a connected account with a device that has an access code, Seam sends a `connected_account.deleted` event, a `device.deleted` event, and an `access_code.deleted` event, but Seam does not remove the access code from the device.
+     *
+     * @param string $connected_account_id ID of the connected account that you want to delete.
+     * @return void OK
+     */
     public function delete(string $connected_account_id): void
     {
         $request_payload = [];
@@ -3347,6 +4267,13 @@ class ConnectedAccountsClient
         );
     }
 
+    /**
+     * Returns a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+     *
+     * @param string $connected_account_id ID of the connected account that you want to get.
+     * @param string $email Email address associated with the connected account that you want to get.
+     * @return ConnectedAccount OK
+     */
     public function get(
         ?string $connected_account_id = null,
         ?string $email = null,
@@ -3369,6 +4296,18 @@ class ConnectedAccountsClient
         return ConnectedAccount::from_json($res->connected_account);
     }
 
+    /**
+     * Returns a list of all [connected accounts](https://docs.seam.co/core-concepts/connected-accounts).
+     *
+     * @param mixed $custom_metadata_has Custom metadata pairs by which you want to filter connected accounts. Returns connected accounts with `custom_metadata` that contains all of the provided key:value pairs.
+     * @param string $customer_key Customer key by which you want to filter connected accounts.
+     * @param int $limit Maximum number of records to return per page.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned connected accounts to include all records that satisfy a partial match using `connected_account_id`, `account_type`, `customer_key`, `custom_metadata`, `user_identifier.username`, `user_identifier.email` or `user_identifier.phone`.
+     * @param string $space_id ID of the space by which you want to filter connected accounts.
+     * @param string $user_identifier_key Your user ID for the user by which you want to filter connected accounts.
+     * @return array OK
+     */
     public function list(
         mixed $custom_metadata_has = null,
         ?string $customer_key = null,
@@ -3419,6 +4358,12 @@ class ConnectedAccountsClient
         );
     }
 
+    /**
+     * Request a [connected account](https://docs.seam.co/core-concepts/connected-accounts) sync attempt for the specified `connected_account_id`.
+     *
+     * @param string $connected_account_id ID of the connected account that you want to sync.
+     * @return void OK
+     */
     public function sync(string $connected_account_id): void
     {
         $request_payload = [];
@@ -3434,6 +4379,17 @@ class ConnectedAccountsClient
         );
     }
 
+    /**
+     * Updates a [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+     *
+     * @param string $connected_account_id ID of the connected account that you want to update.
+     * @param array $accepted_capabilities List of accepted device capabilities that restrict the types of devices that can be connected through this connected account. Valid values are `lock`, `thermostat`, `noise_sensor`, and `access_control`.
+     * @param bool $automatically_manage_new_devices Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+     * @param mixed $custom_metadata Custom metadata that you want to associate with the connected account. Entirely replaces the existing custom metadata object. If a new Connect Webview contains custom metadata and is used to reconnect a connected account, the custom metadata from the Connect Webview will entirely replace the entire custom metadata object on the connected account. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter connected accounts by the desired metadata](https://docs.seam.co/core-concepts/connected-accounts/filtering-connected-accounts-by-custom-metadata).
+     * @param string $customer_key The customer key to associate with this connected account. If provided, the connected account and all resources under the connected account will be moved to this customer. May only be provided if the connected account is not already associated with a customer.
+     * @param string $display_name Human-readable name for the connected account, shown in the dashboard. For example, `Booking from Airbnb House 1`.
+     * @return void OK
+     */
     public function update(
         string $connected_account_id,
         ?array $accepted_capabilities = null,
@@ -3482,6 +4438,12 @@ class ConnectedAccountsSimulateClient
         $this->seam = $seam;
     }
 
+    /**
+     * Simulates a connected account becoming disconnected from Seam. Only applicable for [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     *
+     * @param string $connected_account_id ID of the connected account you want to simulate as disconnected.
+     * @return void OK
+     */
     public function disconnect(string $connected_account_id): void
     {
         $request_payload = [];
@@ -3507,6 +4469,22 @@ class CustomersClient
         $this->seam = $seam;
     }
 
+    /**
+     * Creates a new customer portal magic link with configurable features.
+     *
+     * @param array $customer_resources_filters Filter configuration for resources based on their custom_metadata. Each filter specifies a field, operation, and value to match against resource custom_metadata.
+     * @param string $customization_profile_id The ID of the customization profile to use for the portal.
+     * @param mixed $deep_link Deep link target resource for initial redirect. When set, the portal will navigate directly to the specified resource.
+     * @param bool $exclude_locale_picker Whether to exclude the option to select a locale within the portal UI.
+     * @param mixed $features
+     * @param bool $is_embedded Whether the portal is embedded in another application.
+     * @param mixed $landing_page Configuration for the landing page when the portal loads.
+     * @param string $locale The locale to use for the portal.
+     * @param string $navigation_mode Navigation mode for the portal. 'restricted' tells frontend to hide navigation UI, typically used for embedded deep links.
+     * @param bool $read_only Whether the portal is read-only. When true, the customer can browse the portal but cannot perform any mutating action; write requests made with the portal's client session are rejected.
+     * @param mixed $customer_data
+     * @return CustomerPortal OK
+     */
     public function create_portal(
         ?array $customer_resources_filters = null,
         ?string $customization_profile_id = null,
@@ -3569,6 +4547,31 @@ class CustomersClient
         return CustomerPortal::from_json($res->customer_portal);
     }
 
+    /**
+     * Deletes customer data including resources like spaces, properties, rooms, users, etc.
+     * This will delete the partner resources and any related Seam resources (user identities, access grants, spaces).
+     *
+     * @param array $access_grant_keys List of access grant keys to delete.
+     * @param array $booking_keys List of booking keys to delete.
+     * @param array $building_keys List of building keys to delete.
+     * @param array $common_area_keys List of common area keys to delete.
+     * @param array $customer_keys List of customer keys to delete all data for.
+     * @param array $facility_keys List of facility keys to delete.
+     * @param array $guest_keys List of guest keys to delete.
+     * @param array $listing_keys List of listing keys to delete.
+     * @param array $property_keys List of property keys to delete.
+     * @param array $property_listing_keys List of property listing keys to delete.
+     * @param array $reservation_keys List of reservation keys to delete.
+     * @param array $resident_keys List of resident keys to delete.
+     * @param array $room_keys List of room keys to delete.
+     * @param array $space_keys List of space keys to delete.
+     * @param array $staff_member_keys List of staff member keys to delete.
+     * @param array $tenant_keys List of tenant keys to delete.
+     * @param array $unit_keys List of unit keys to delete.
+     * @param array $user_identity_keys List of user identity keys to delete.
+     * @param array $user_keys List of user keys to delete.
+     * @return void OK
+     */
     public function delete_data(
         ?array $access_grant_keys = null,
         ?array $booking_keys = null,
@@ -3657,6 +4660,31 @@ class CustomersClient
         );
     }
 
+    /**
+     * Pushes customer data including resources like spaces, properties, rooms, users, etc.
+     *
+     * @param string $customer_key Your unique identifier for the customer.
+     * @param array $access_grants List of access grants.
+     * @param array $bookings List of bookings.
+     * @param array $buildings List of buildings.
+     * @param array $common_areas List of shared common areas.
+     * @param array $facilities List of gym or fitness facilities.
+     * @param array $guests List of guests.
+     * @param array $listings List of property listings.
+     * @param array $properties List of short-term rental properties.
+     * @param array $property_listings List of property listings.
+     * @param array $reservations List of reservations.
+     * @param array $residents List of residents.
+     * @param array $rooms List of hotel or hospitality rooms.
+     * @param array $sites List of general sites or areas.
+     * @param array $spaces List of general spaces or areas.
+     * @param array $staff_members List of staff members.
+     * @param array $tenants List of tenants.
+     * @param array $units List of multi-family residential units.
+     * @param array $user_identities List of user identities.
+     * @param array $users List of users.
+     * @return void OK
+     */
     public function push_data(
         string $customer_key,
         ?array $access_grants = null,
@@ -3762,6 +4790,15 @@ class DevicesClient
         $this->unmanaged = new DevicesUnmanagedClient($seam);
     }
 
+    /**
+     * Returns a specified [device](https://docs.seam.co/core-concepts/devices).
+     *
+     * You must specify either `device_id` or `name`.
+     *
+     * @param string $device_id ID of the device that you want to get.
+     * @param string $name Name of the device that you want to get.
+     * @return Device OK
+     */
     public function get(?string $device_id = null, ?string $name = null): Device
     {
         $request_payload = [];
@@ -3782,6 +4819,27 @@ class DevicesClient
         return Device::from_json($res->device);
     }
 
+    /**
+     * Returns a list of all [devices](https://docs.seam.co/core-concepts/devices).
+     *
+     * @param string $connect_webview_id ID of the Connect Webview for which you want to list devices.
+     * @param string $connected_account_id ID of the connected account for which you want to list devices.
+     * @param array $connected_account_ids Array of IDs of the connected accounts for which you want to list devices.
+     * @param string $created_before Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+     * @param mixed $custom_metadata_has Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+     * @param string $customer_key Customer key for which you want to list devices.
+     * @param array $device_ids Array of device IDs for which you want to list devices.
+     * @param string $device_type Device type for which you want to list devices.
+     * @param array $device_types Array of device types for which you want to list devices.
+     * @param float $limit Numerical limit on the number of devices to return.
+     * @param string $manufacturer Manufacturer for which you want to list devices.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+     * @param string $space_id ID of the space for which you want to list devices.
+     * @param string $unstable_location_id
+     * @param string $user_identifier_key Your own internal user ID for the user for which you want to list devices.
+     * @return array OK
+     */
     public function list(
         ?string $connect_webview_id = null,
         ?string $connected_account_id = null,
@@ -3865,6 +4923,16 @@ class DevicesClient
         return array_map(fn($r) => Device::from_json($r), $res->devices);
     }
 
+    /**
+     * Returns a list of all device providers.
+     *
+     * The information that this endpoint returns for each provider includes a set of [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags), such as `device_provider.can_remotely_unlock`. If at least one supported device from a provider has a specific capability, the corresponding capability flag is `true`.
+     *
+     * When you create a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews), you can customize the providers—that is, the brands—that it displays. In the `/connect_webviews/create` request, include the desired set of device provider keys in the `accepted_providers` parameter. See also [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
+     *
+     * @param string $provider_category Category for which you want to list providers.
+     * @return array OK
+     */
     public function list_device_providers(
         ?string $provider_category = null,
     ): array {
@@ -3886,6 +4954,12 @@ class DevicesClient
         );
     }
 
+    /**
+     * Updates provider-specific metadata for devices.
+     *
+     * @param array $devices Array of devices with provider metadata to update
+     * @return void OK
+     */
     public function report_provider_metadata(array $devices): void
     {
         $request_payload = [];
@@ -3901,6 +4975,19 @@ class DevicesClient
         );
     }
 
+    /**
+     * Updates a specified [device](https://docs.seam.co/core-concepts/devices).
+     *
+     * You can add or change [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for a device, change the device's name, or [convert a managed device to unmanaged](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+     *
+     * @param string $device_id ID of the device that you want to update.
+     * @param bool $backup_access_code_pool_enabled Indicates whether the device's [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) is enabled. Set to `false` to disable the pool: Seam stops refilling it and removes any backup codes that have not yet been pulled into active use.
+     * @param mixed $custom_metadata Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter devices by the desired metadata](https://docs.seam.co/core-concepts/devices/filtering-devices-by-custom-metadata).
+     * @param bool $is_managed Indicates whether the device is managed. To unmanage a device, set `is_managed` to `false`.
+     * @param string $name Name for the device.
+     * @param mixed $properties
+     * @return void OK
+     */
     public function update(
         string $device_id,
         ?bool $backup_access_code_pool_enabled = null,
@@ -3949,6 +5036,12 @@ class DevicesSimulateClient
         $this->seam = $seam;
     }
 
+    /**
+     * Simulates connecting a device to Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+     *
+     * @param string $device_id ID of the device that you want to simulate connecting to Seam.
+     * @return void OK
+     */
     public function connect(string $device_id): void
     {
         $request_payload = [];
@@ -3964,6 +5057,15 @@ class DevicesSimulateClient
         );
     }
 
+    /**
+     * Simulates bringing the Wi‑Fi hub (bridge) back online for a device.
+     * Only applicable for sandbox workspaces and currently
+     * implemented for August and TTLock locks.
+     * This will clear the `hub_disconnected` error on the device.
+     *
+     * @param string $device_id ID of the device whose hub you want to reconnect.
+     * @return void OK
+     */
     public function connect_to_hub(string $device_id): void
     {
         $request_payload = [];
@@ -3979,6 +5081,12 @@ class DevicesSimulateClient
         );
     }
 
+    /**
+     * Simulates disconnecting a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+     *
+     * @param string $device_id ID of the device that you want to simulate disconnecting from Seam.
+     * @return void OK
+     */
     public function disconnect(string $device_id): void
     {
         $request_payload = [];
@@ -3994,6 +5102,16 @@ class DevicesSimulateClient
         );
     }
 
+    /**
+     * Simulates taking the Wi‑Fi hub (bridge) offline for a device.
+     * Only applicable for sandbox workspaces and currently
+     * implemented for August, TTLock, and IglooHome devices.
+     * This will set the `hub_disconnected` error on the device, or mark the
+     * IglooHome bridge offline in sandbox.
+     *
+     * @param string $device_id ID of the device whose hub you want to disconnect.
+     * @return void OK
+     */
     public function disconnect_from_hub(string $device_id): void
     {
         $request_payload = [];
@@ -4009,6 +5127,15 @@ class DevicesSimulateClient
         );
     }
 
+    /**
+     * Toggle the simulated Nuki Smart Hosting subscription for a device (sandbox only).
+     * Send `is_expired: true` to simulate an expired subscription, or `false` to simulate an active subscription.
+     * The actual device error is created/cleared by the poller after this state change.
+     *
+     * @param string $device_id
+     * @param bool $is_expired
+     * @return void OK
+     */
     public function paid_subscription(string $device_id, bool $is_expired): void
     {
         $request_payload = [];
@@ -4027,6 +5154,12 @@ class DevicesSimulateClient
         );
     }
 
+    /**
+     * Simulates removing a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+     *
+     * @param string $device_id ID of the device that you want to simulate removing from Seam.
+     * @return void OK
+     */
     public function remove(string $device_id): void
     {
         $request_payload = [];
@@ -4052,6 +5185,17 @@ class DevicesUnmanagedClient
         $this->seam = $seam;
     }
 
+    /**
+     * Returns a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+     *
+     * An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+     *
+     * You must specify either `device_id` or `name`.
+     *
+     * @param string $device_id ID of the unmanaged device that you want to get.
+     * @param string $name Name of the unmanaged device that you want to get.
+     * @return UnmanagedDevice OK
+     */
     public function get(
         ?string $device_id = null,
         ?string $name = null,
@@ -4074,6 +5218,29 @@ class DevicesUnmanagedClient
         return UnmanagedDevice::from_json($res->device);
     }
 
+    /**
+     * Returns a list of all [unmanaged devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+     *
+     * An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+     *
+     * @param string $connect_webview_id ID of the Connect Webview for which you want to list devices.
+     * @param string $connected_account_id ID of the connected account for which you want to list devices.
+     * @param array $connected_account_ids Array of IDs of the connected accounts for which you want to list devices.
+     * @param string $created_before Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+     * @param mixed $custom_metadata_has Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+     * @param string $customer_key Customer key for which you want to list devices.
+     * @param array $device_ids Array of device IDs for which you want to list devices.
+     * @param string $device_type Device type for which you want to list devices.
+     * @param array $device_types Array of device types for which you want to list devices.
+     * @param float $limit Numerical limit on the number of devices to return.
+     * @param string $manufacturer Manufacturer for which you want to list devices.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+     * @param string $space_id ID of the space for which you want to list devices.
+     * @param string $unstable_location_id
+     * @param string $user_identifier_key Your own internal user ID for the user for which you want to list devices.
+     * @return array OK
+     */
     public function list(
         ?string $connect_webview_id = null,
         ?string $connected_account_id = null,
@@ -4160,6 +5327,16 @@ class DevicesUnmanagedClient
         );
     }
 
+    /**
+     * Updates a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). To convert an unmanaged device to managed, set `is_managed` to `true`.
+     *
+     * An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+     *
+     * @param string $device_id ID of the unmanaged device that you want to update.
+     * @param mixed $custom_metadata Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs.
+     * @param bool $is_managed Indicates whether the device is managed. Set this parameter to `true` to convert an unmanaged device to managed.
+     * @return void OK
+     */
     public function update(
         string $device_id,
         mixed $custom_metadata = null,
@@ -4194,6 +5371,14 @@ class EventsClient
         $this->seam = $seam;
     }
 
+    /**
+     * Returns a specified event. This endpoint returns the same event that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to retrieve an event that already took place.
+     *
+     * @param string $event_id Unique identifier for the event that you want to get.
+     * @param string $device_id Unique identifier for the device that triggered the event that you want to get.
+     * @param string $event_type Type of the event that you want to get.
+     * @return Event OK
+     */
     public function get(
         ?string $event_id = null,
         ?string $device_id = null,
@@ -4220,6 +5405,39 @@ class EventsClient
         return Event::from_json($res->event);
     }
 
+    /**
+     * Returns a list of all events. This endpoint returns the same events that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to filter or see events that already took place.
+     *
+     * @param string $access_code_id ID of the access code for which you want to list events.
+     * @param array $access_code_ids IDs of the access codes for which you want to list events.
+     * @param string $access_grant_id ID of the access grant for which you want to list events.
+     * @param array $access_grant_ids IDs of the access grants for which you want to list events.
+     * @param string $access_method_id ID of the access method for which you want to list events.
+     * @param array $access_method_ids IDs of the access methods for which you want to list events.
+     * @param string $acs_access_group_id ID of the ACS access group for which you want to list events.
+     * @param string $acs_credential_id ID of the ACS credential for which you want to list events.
+     * @param string $acs_encoder_id ID of the ACS encoder for which you want to list events.
+     * @param string $acs_entrance_id ID of the ACS entrance for which you want to list events.
+     * @param string $acs_system_id ID of the access system for which you want to list events.
+     * @param array $acs_system_ids IDs of the access systems for which you want to list events.
+     * @param string $acs_user_id ID of the ACS user for which you want to list events.
+     * @param array $between Lower and upper timestamps to define an exclusive interval containing the events that you want to list. You must include `since` or `between`.
+     * @param string $connect_webview_id ID of the Connect Webview for which you want to list events.
+     * @param string $connected_account_id ID of the connected account for which you want to list events.
+     * @param string $customer_key Customer key for which you want to list events.
+     * @param string $device_id ID of the device for which you want to list events.
+     * @param array $device_ids IDs of the devices for which you want to list events.
+     * @param array $event_ids IDs of the events that you want to list.
+     * @param string $event_type Type of the events that you want to list.
+     * @param array $event_types Types of the events that you want to list.
+     * @param float $limit Numerical limit on the number of events to return.
+     * @param string $since Timestamp to indicate the beginning generation time for the events that you want to list. You must include `since` or `between`.
+     * @param string $space_id ID of the space for which you want to list events.
+     * @param array $space_ids IDs of the spaces for which you want to list events.
+     * @param float $unstable_offset Offset for the events that you want to list.
+     * @param string $user_identity_id ID of the user identity for which you want to list events.
+     * @return array OK
+     */
     public function list(
         ?string $access_code_id = null,
         ?array $access_code_ids = null,
@@ -4356,6 +5574,12 @@ class InstantKeysClient
         $this->seam = $seam;
     }
 
+    /**
+     * Deletes a specified [Instant Key](https://docs.seam.co/capability-guides/instant-keys).
+     *
+     * @param string $instant_key_id ID of the Instant Key that you want to delete.
+     * @return void OK
+     */
     public function delete(string $instant_key_id): void
     {
         $request_payload = [];
@@ -4371,6 +5595,13 @@ class InstantKeysClient
         );
     }
 
+    /**
+     * Gets an [instant key](https://docs.seam.co/capability-guides/instant-keys).
+     *
+     * @param string $instant_key_id ID of the instant key to get.
+     * @param string $instant_key_url URL of the instant key to get.
+     * @return InstantKey OK
+     */
     public function get(
         ?string $instant_key_id = null,
         ?string $instant_key_url = null,
@@ -4393,6 +5624,12 @@ class InstantKeysClient
         return InstantKey::from_json($res->instant_key);
     }
 
+    /**
+     * Returns a list of all [instant keys](https://docs.seam.co/capability-guides/instant-keys).
+     *
+     * @param string $user_identity_id ID of the user identity by which you want to filter the list of Instant Keys.
+     * @return array OK
+     */
     public function list(?string $user_identity_id = null): array
     {
         $request_payload = [];
@@ -4424,6 +5661,14 @@ class LocksClient
         $this->simulate = new LocksSimulateClient($seam);
     }
 
+    /**
+     * Configures the auto-lock setting for a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+     *
+     * @param bool $auto_lock_enabled Whether to enable or disable auto-lock.
+     * @param string $device_id ID of the lock for which you want to configure the auto-lock.
+     * @param float $auto_lock_delay_seconds Delay in seconds before the lock automatically locks. Required when enabling auto-lock. Must be between 1 and 60.
+     * @return ActionAttempt OK
+     */
     public function configure_auto_lock(
         bool $auto_lock_enabled,
         string $device_id,
@@ -4461,6 +5706,14 @@ class LocksClient
         return $action_attempt;
     }
 
+    /**
+     * Returns a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+     *
+     * @param string $device_id ID of the lock that you want to get.
+     * @param string $name Name of the lock that you want to get.
+     * @return Device OK
+     * @deprecated Use `/devices/get` instead.
+     */
     public function get(?string $device_id = null, ?string $name = null): Device
     {
         $request_payload = [];
@@ -4481,6 +5734,27 @@ class LocksClient
         return Device::from_json($res->device);
     }
 
+    /**
+     * Returns a list of all [locks](https://docs.seam.co/low-level-apis/smart-locks).
+     *
+     * @param string $connect_webview_id ID of the Connect Webview for which you want to list devices.
+     * @param string $connected_account_id ID of the connected account for which you want to list devices.
+     * @param array $connected_account_ids Array of IDs of the connected accounts for which you want to list devices.
+     * @param string $created_before Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+     * @param mixed $custom_metadata_has Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+     * @param string $customer_key Customer key for which you want to list devices.
+     * @param array $device_ids Array of device IDs for which you want to list devices.
+     * @param string $device_type Device type of the locks that you want to list.
+     * @param array $device_types Device types of the locks that you want to list.
+     * @param float $limit Numerical limit on the number of devices to return.
+     * @param string $manufacturer Manufacturer of the locks that you want to list.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+     * @param string $space_id ID of the space for which you want to list devices.
+     * @param string $unstable_location_id
+     * @param string $user_identifier_key Your own internal user ID for the user for which you want to list devices.
+     * @return array OK
+     */
     public function list(
         ?string $connect_webview_id = null,
         ?string $connected_account_id = null,
@@ -4564,6 +5838,12 @@ class LocksClient
         return array_map(fn($r) => Device::from_json($r), $res->devices);
     }
 
+    /**
+     * Locks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+     *
+     * @param string $device_id ID of the lock that you want to lock.
+     * @return ActionAttempt OK
+     */
     public function lock_door(
         string $device_id,
         bool $wait_for_action_attempt = true,
@@ -4591,6 +5871,12 @@ class LocksClient
         return $action_attempt;
     }
 
+    /**
+     * Unlocks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+     *
+     * @param string $device_id ID of the lock that you want to unlock.
+     * @return ActionAttempt OK
+     */
     public function unlock_door(
         string $device_id,
         bool $wait_for_action_attempt = true,
@@ -4628,6 +5914,13 @@ class LocksSimulateClient
         $this->seam = $seam;
     }
 
+    /**
+     * Simulates the entry of a code on a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     *
+     * @param string $code Code that you want to simulate entering on a keypad.
+     * @param string $device_id ID of the device for which you want to simulate a keypad code entry.
+     * @return ActionAttempt OK
+     */
     public function keypad_code_entry(
         string $code,
         string $device_id,
@@ -4659,6 +5952,12 @@ class LocksSimulateClient
         return $action_attempt;
     }
 
+    /**
+     * Simulates a manual lock action using a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     *
+     * @param string $device_id ID of the device for which you want to simulate a manual lock action using a keypad.
+     * @return ActionAttempt OK
+     */
     public function manual_lock_via_keypad(
         string $device_id,
         bool $wait_for_action_attempt = true,
@@ -4699,6 +5998,27 @@ class NoiseSensorsClient
         $this->simulate = new NoiseSensorsSimulateClient($seam);
     }
 
+    /**
+     * Returns a list of all [noise sensors](https://docs.seam.co/capability-guides/noise-sensors).
+     *
+     * @param string $connect_webview_id ID of the Connect Webview for which you want to list devices.
+     * @param string $connected_account_id ID of the connected account for which you want to list devices.
+     * @param array $connected_account_ids Array of IDs of the connected accounts for which you want to list devices.
+     * @param string $created_before Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+     * @param mixed $custom_metadata_has Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+     * @param string $customer_key Customer key for which you want to list devices.
+     * @param array $device_ids Array of device IDs for which you want to list devices.
+     * @param string $device_type Device type of the noise sensors that you want to list.
+     * @param array $device_types Device types of the noise sensors that you want to list.
+     * @param float $limit Numerical limit on the number of devices to return.
+     * @param string $manufacturer Manufacturers of the noise sensors that you want to list.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+     * @param string $space_id ID of the space for which you want to list devices.
+     * @param string $unstable_location_id
+     * @param string $user_identifier_key Your own internal user ID for the user for which you want to list devices.
+     * @return array OK
+     */
     public function list(
         ?string $connect_webview_id = null,
         ?string $connected_account_id = null,
@@ -4792,6 +6112,17 @@ class NoiseSensorsNoiseThresholdsClient
         $this->seam = $seam;
     }
 
+    /**
+     * Creates a new [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+     *
+     * @param string $device_id ID of the device for which you want to create a noise threshold.
+     * @param string $ends_daily_at Time at which the new noise threshold should become inactive daily.
+     * @param string $starts_daily_at Time at which the new noise threshold should become active daily.
+     * @param string $name Name of the new noise threshold.
+     * @param float $noise_threshold_decibels Noise level in decibels for the new noise threshold.
+     * @param float $noise_threshold_nrs Noise level in Noiseaware Noise Risk Score (NRS) for the new noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).
+     * @return NoiseThreshold OK
+     */
     public function create(
         string $device_id,
         string $ends_daily_at,
@@ -4832,6 +6163,13 @@ class NoiseSensorsNoiseThresholdsClient
         return NoiseThreshold::from_json($res->noise_threshold);
     }
 
+    /**
+     * Deletes a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) from a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+     *
+     * @param string $device_id ID of the device that contains the noise threshold that you want to delete.
+     * @param string $noise_threshold_id ID of the noise threshold that you want to delete.
+     * @return void OK
+     */
     public function delete(string $device_id, string $noise_threshold_id): void
     {
         $request_payload = [];
@@ -4850,6 +6188,12 @@ class NoiseSensorsNoiseThresholdsClient
         );
     }
 
+    /**
+     * Returns a specified [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+     *
+     * @param string $noise_threshold_id ID of the noise threshold that you want to get.
+     * @return NoiseThreshold OK
+     */
     public function get(string $noise_threshold_id): NoiseThreshold
     {
         $request_payload = [];
@@ -4867,6 +6211,12 @@ class NoiseSensorsNoiseThresholdsClient
         return NoiseThreshold::from_json($res->noise_threshold);
     }
 
+    /**
+     * Returns a list of all [noise thresholds](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+     *
+     * @param string $device_id ID of the device for which you want to list noise thresholds.
+     * @return array OK
+     */
     public function list(string $device_id): array
     {
         $request_payload = [];
@@ -4887,6 +6237,18 @@ class NoiseSensorsNoiseThresholdsClient
         );
     }
 
+    /**
+     * Updates a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+     *
+     * @param string $device_id ID of the device that contains the noise threshold that you want to update.
+     * @param string $noise_threshold_id ID of the noise threshold that you want to update.
+     * @param string $ends_daily_at Time at which the noise threshold should become inactive daily.
+     * @param string $name Name of the noise threshold that you want to update.
+     * @param float $noise_threshold_decibels Noise level in decibels for the noise threshold.
+     * @param float $noise_threshold_nrs Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).
+     * @param string $starts_daily_at Time at which the noise threshold should become active daily.
+     * @return void OK
+     */
     public function update(
         string $device_id,
         string $noise_threshold_id,
@@ -4939,6 +6301,12 @@ class NoiseSensorsSimulateClient
         $this->seam = $seam;
     }
 
+    /**
+     * Simulates the triggering of a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     *
+     * @param string $device_id ID of the device for which you want to simulate the triggering of a noise threshold.
+     * @return void OK
+     */
     public function trigger_noise_threshold(string $device_id): void
     {
         $request_payload = [];
@@ -4965,6 +6333,12 @@ class PhonesClient
         $this->simulate = new PhonesSimulateClient($seam);
     }
 
+    /**
+     * Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see [App User Lost Phone Process](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process).
+     *
+     * @param string $device_id Device ID of the phone that you want to deactivate.
+     * @return void OK
+     */
     public function deactivate(string $device_id): void
     {
         $request_payload = [];
@@ -4980,6 +6354,12 @@ class PhonesClient
         );
     }
 
+    /**
+     * Returns a specified [phone](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity).
+     *
+     * @param string $device_id Device ID of the phone that you want to get.
+     * @return Phone OK
+     */
     public function get(string $device_id): Phone
     {
         $request_payload = [];
@@ -4997,6 +6377,13 @@ class PhonesClient
         return Phone::from_json($res->phone);
     }
 
+    /**
+     * Returns a list of all [phones](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity). To filter the list of returned phones by a specific owner user identity or credential, include the `owner_user_identity_id` or `acs_credential_id`, respectively, in the request body.
+     *
+     * @param string $acs_credential_id ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) by which you want to filter the list of returned phones.
+     * @param string $owner_user_identity_id ID of the user identity that represents the owner by which you want to filter the list of returned phones.
+     * @return array OK
+     */
     public function list(
         ?string $acs_credential_id = null,
         ?string $owner_user_identity_id = null,
@@ -5031,6 +6418,15 @@ class PhonesSimulateClient
         $this->seam = $seam;
     }
 
+    /**
+     * Creates a new simulated phone in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Creating a Simulated Phone for a User Identity](https://docs.seam.co/capability-guides/mobile-access/developing-in-a-sandbox-workspace#creating-a-simulated-phone-for-a-user-identity).
+     *
+     * @param string $user_identity_id ID of the user identity that you want to associate with the simulated phone.
+     * @param mixed $assa_abloy_metadata ASSA ABLOY metadata that you want to associate with the simulated phone.
+     * @param string $custom_sdk_installation_id ID of the custom SDK installation that you want to use for the simulated phone.
+     * @param mixed $phone_metadata Metadata that you want to associate with the simulated phone.
+     * @return Phone OK
+     */
     public function create_sandbox_phone(
         string $user_identity_id,
         mixed $assa_abloy_metadata = null,
@@ -5073,6 +6469,13 @@ class SpacesClient
         $this->seam = $seam;
     }
 
+    /**
+     * Adds [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) to a specific space.
+     *
+     * @param array $acs_entrance_ids IDs of the entrances that you want to add to the space.
+     * @param string $space_id ID of the space to which you want to add entrances.
+     * @return void OK
+     */
     public function add_acs_entrances(
         array $acs_entrance_ids,
         string $space_id,
@@ -5093,6 +6496,13 @@ class SpacesClient
         );
     }
 
+    /**
+     * Adds a [connected account](https://docs.seam.co/core-concepts/connected-accounts) to a specific space.
+     *
+     * @param string $connected_account_id ID of the connected account that you want to add to the space.
+     * @param string $space_id ID of the space to which you want to add the connected account.
+     * @return void OK
+     */
     public function add_connected_account(
         string $connected_account_id,
         string $space_id,
@@ -5113,6 +6523,13 @@ class SpacesClient
         );
     }
 
+    /**
+     * Adds devices to a specific space.
+     *
+     * @param array $device_ids IDs of the devices that you want to add to the space.
+     * @param string $space_id ID of the space to which you want to add devices.
+     * @return void OK
+     */
     public function add_devices(array $device_ids, string $space_id): void
     {
         $request_payload = [];
@@ -5131,6 +6548,18 @@ class SpacesClient
         );
     }
 
+    /**
+     * Creates a new space.
+     *
+     * @param string $name Name of the space that you want to create.
+     * @param array $acs_entrance_ids IDs of the entrances that you want to add to the new space.
+     * @param array $connected_account_ids IDs of connected accounts to associate with the new space. Persisted on seam.location_third_party_account so the UI can show which provider account(s) a space came from.
+     * @param mixed $customer_data Reservation/stay-related defaults for the space.
+     * @param string $customer_key Customer key for which you want to create the space.
+     * @param array $device_ids IDs of the devices that you want to add to the new space.
+     * @param string $space_key Unique key for the space within the workspace.
+     * @return Space OK
+     */
     public function create(
         string $name,
         ?array $acs_entrance_ids = null,
@@ -5173,6 +6602,12 @@ class SpacesClient
         return Space::from_json($res->space);
     }
 
+    /**
+     * Deletes a space.
+     *
+     * @param string $space_id ID of the space that you want to delete.
+     * @return void OK
+     */
     public function delete(string $space_id): void
     {
         $request_payload = [];
@@ -5188,6 +6623,13 @@ class SpacesClient
         );
     }
 
+    /**
+     * Gets a space.
+     *
+     * @param string $space_id ID of the space that you want to get.
+     * @param string $space_key Unique key of the space that you want to get.
+     * @return Space OK
+     */
     public function get(
         ?string $space_id = null,
         ?string $space_key = null,
@@ -5210,6 +6652,15 @@ class SpacesClient
         return Space::from_json($res->space);
     }
 
+    /**
+     * Gets all related resources for one or more Spaces.
+     *
+     * @param array $exclude
+     * @param array $include
+     * @param array $space_ids IDs of the spaces that you want to get along with their related resources.
+     * @param array $space_keys Keys of the spaces that you want to get along with their related resources.
+     * @return Batch OK
+     */
     public function get_related(
         ?array $exclude = null,
         ?array $include = null,
@@ -5240,6 +6691,16 @@ class SpacesClient
         return Batch::from_json($res->batch);
     }
 
+    /**
+     * Returns a list of all spaces.
+     *
+     * @param string $customer_key Customer key for which you want to list spaces.
+     * @param float $limit Maximum number of records to return per page.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned spaces to include all records that satisfy a partial match using `name`, `space_key`, or `customer_key`.
+     * @param string $space_key Filter spaces by space_key.
+     * @return array OK
+     */
     public function list(
         ?string $customer_key = null,
         ?float $limit = null,
@@ -5279,6 +6740,13 @@ class SpacesClient
         return array_map(fn($r) => Space::from_json($r), $res->spaces);
     }
 
+    /**
+     * Removes [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) from a specific space.
+     *
+     * @param array $acs_entrance_ids IDs of the entrances that you want to remove from the space.
+     * @param string $space_id ID of the space from which you want to remove entrances.
+     * @return void OK
+     */
     public function remove_acs_entrances(
         array $acs_entrance_ids,
         string $space_id,
@@ -5299,6 +6767,13 @@ class SpacesClient
         );
     }
 
+    /**
+     * Removes a [connected account](https://docs.seam.co/core-concepts/connected-accounts) from a specific space.
+     *
+     * @param string $connected_account_id ID of the connected account that you want to remove from the space.
+     * @param string $space_id ID of the space from which you want to remove the connected account.
+     * @return void OK
+     */
     public function remove_connected_account(
         string $connected_account_id,
         string $space_id,
@@ -5319,6 +6794,13 @@ class SpacesClient
         );
     }
 
+    /**
+     * Removes devices from a specific space.
+     *
+     * @param array $device_ids IDs of the devices that you want to remove from the space.
+     * @param string $space_id ID of the space from which you want to remove devices.
+     * @return void OK
+     */
     public function remove_devices(array $device_ids, string $space_id): void
     {
         $request_payload = [];
@@ -5337,6 +6819,17 @@ class SpacesClient
         );
     }
 
+    /**
+     * Updates an existing space.
+     *
+     * @param array $acs_entrance_ids IDs of the entrances that you want to set for the space. If specified, this will replace all existing entrances.
+     * @param mixed $customer_data Reservation/stay-related defaults for the space. Only the keys you provide are updated; omit a key to leave it unchanged. Pass null on a key to clear it.
+     * @param array $device_ids IDs of the devices that you want to set for the space. If specified, this will replace all existing devices.
+     * @param string $name Name of the space.
+     * @param string $space_id ID of the space that you want to update.
+     * @param string $space_key Unique key of the space that you want to update.
+     * @return Space OK
+     */
     public function update(
         ?array $acs_entrance_ids = null,
         mixed $customer_data = null,
@@ -5390,6 +6883,13 @@ class ThermostatsClient
         $this->simulate = new ThermostatsSimulateClient($seam);
     }
 
+    /**
+     * Activates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $climate_preset_key Climate preset key of the climate preset that you want to activate.
+     * @param string $device_id ID of the thermostat device for which you want to activate a climate preset.
+     * @return ActionAttempt OK
+     */
     public function activate_climate_preset(
         string $climate_preset_key,
         string $device_id,
@@ -5421,6 +6921,14 @@ class ThermostatsClient
         return $action_attempt;
     }
 
+    /**
+     * Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [cool mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+     *
+     * @param string $device_id ID of the thermostat device that you want to set to cool mode.
+     * @param float $cooling_set_point_celsius [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+     * @param float $cooling_set_point_fahrenheit [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+     * @return ActionAttempt OK
+     */
     public function cool(
         string $device_id,
         ?float $cooling_set_point_celsius = null,
@@ -5460,6 +6968,23 @@ class ThermostatsClient
         return $action_attempt;
     }
 
+    /**
+     * Creates a [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $climate_preset_key Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+     * @param string $device_id ID of the thermostat device for which you want create a climate preset.
+     * @param string $climate_preset_mode The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+     * @param float $cooling_set_point_celsius Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+     * @param float $cooling_set_point_fahrenheit Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+     * @param mixed $ecobee_metadata Metadata specific to the Ecobee climate, if applicable.
+     * @param string $fan_mode_setting Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+     * @param float $heating_set_point_celsius Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+     * @param float $heating_set_point_fahrenheit Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+     * @param string $hvac_mode_setting Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+     * @param bool $manual_override_allowed Indicates whether a person at the thermostat or using the API can change the thermostat's settings.
+     * @param string $name User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+     * @return void OK
+     */
     public function create_climate_preset(
         string $climate_preset_key,
         string $device_id,
@@ -5530,6 +7055,13 @@ class ThermostatsClient
         );
     }
 
+    /**
+     * Deletes a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $climate_preset_key Climate preset key of the climate preset that you want to delete.
+     * @param string $device_id ID of the thermostat device for which you want to delete a climate preset.
+     * @return void OK
+     */
     public function delete_climate_preset(
         string $climate_preset_key,
         string $device_id,
@@ -5550,6 +7082,14 @@ class ThermostatsClient
         );
     }
 
+    /**
+     * Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+     *
+     * @param string $device_id ID of the thermostat device that you want to set to heat mode.
+     * @param float $heating_set_point_celsius [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+     * @param float $heating_set_point_fahrenheit [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+     * @return ActionAttempt OK
+     */
     public function heat(
         string $device_id,
         ?float $heating_set_point_celsius = null,
@@ -5589,6 +7129,16 @@ class ThermostatsClient
         return $action_attempt;
     }
 
+    /**
+     * Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat-cool ("auto") mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+     *
+     * @param string $device_id ID of the thermostat device that you want to set to heat-cool mode.
+     * @param float $cooling_set_point_celsius [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+     * @param float $cooling_set_point_fahrenheit [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+     * @param float $heating_set_point_celsius [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+     * @param float $heating_set_point_fahrenheit [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+     * @return ActionAttempt OK
+     */
     public function heat_cool(
         string $device_id,
         ?float $cooling_set_point_celsius = null,
@@ -5640,6 +7190,27 @@ class ThermostatsClient
         return $action_attempt;
     }
 
+    /**
+     * Returns a list of all [thermostats](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $connect_webview_id ID of the Connect Webview for which you want to list devices.
+     * @param string $connected_account_id ID of the connected account for which you want to list devices.
+     * @param array $connected_account_ids Array of IDs of the connected accounts for which you want to list devices.
+     * @param string $created_before Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+     * @param mixed $custom_metadata_has Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+     * @param string $customer_key Customer key for which you want to list devices.
+     * @param array $device_ids Array of device IDs for which you want to list devices.
+     * @param string $device_type Device type by which you want to filter thermostat devices.
+     * @param array $device_types Array of device types by which you want to filter thermostat devices.
+     * @param float $limit Numerical limit on the number of devices to return.
+     * @param string $manufacturer Manufacturer by which you want to filter thermostat devices.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+     * @param string $space_id ID of the space for which you want to list devices.
+     * @param string $unstable_location_id
+     * @param string $user_identifier_key Your own internal user ID for the user for which you want to list devices.
+     * @return array OK
+     */
     public function list(
         ?string $connect_webview_id = null,
         ?string $connected_account_id = null,
@@ -5723,6 +7294,12 @@ class ThermostatsClient
         return array_map(fn($r) => Device::from_json($r), $res->devices);
     }
 
+    /**
+     * Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to ["off" mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+     *
+     * @param string $device_id ID of the thermostat device that you want to set to off mode.
+     * @return ActionAttempt OK
+     */
     public function off(
         string $device_id,
         bool $wait_for_action_attempt = true,
@@ -5750,6 +7327,13 @@ class ThermostatsClient
         return $action_attempt;
     }
 
+    /**
+     * Sets a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) as the ["fallback"](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) preset for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $climate_preset_key Climate preset key of the climate preset that you want to set as the fallback climate preset.
+     * @param string $device_id ID of the thermostat device for which you want to set the fallback climate preset.
+     * @return void OK
+     */
     public function set_fallback_climate_preset(
         string $climate_preset_key,
         string $device_id,
@@ -5770,6 +7354,14 @@ class ThermostatsClient
         );
     }
 
+    /**
+     * Sets the [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $device_id ID of the thermostat device for which you want to set the fan mode.
+     * @param string $fan_mode Fan mode setting for the thermostat, such as `auto`, `on`, or `circulate`.
+     * @param string $fan_mode_setting [Fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) that you want to set for the thermostat.
+     * @return ActionAttempt OK
+     */
     public function set_fan_mode(
         string $device_id,
         ?string $fan_mode = null,
@@ -5805,6 +7397,17 @@ class ThermostatsClient
         return $action_attempt;
     }
 
+    /**
+     * Sets the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $device_id ID of the thermostat device for which you want to set the HVAC mode.
+     * @param string $hvac_mode_setting
+     * @param float $cooling_set_point_celsius [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+     * @param float $cooling_set_point_fahrenheit [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+     * @param float $heating_set_point_celsius [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+     * @param float $heating_set_point_fahrenheit [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+     * @return ActionAttempt OK
+     */
     public function set_hvac_mode(
         string $device_id,
         string $hvac_mode_setting,
@@ -5860,6 +7463,16 @@ class ThermostatsClient
         return $action_attempt;
     }
 
+    /**
+     * Sets a [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) for a specified thermostat. Seam emits a `thermostat.temperature_threshold_exceeded` event and adds a warning on a thermostat if it reports a temperature outside the threshold range.
+     *
+     * @param string $device_id ID of the thermostat device for which you want to set a temperature threshold.
+     * @param float $lower_limit_celsius Lower temperature limit in in °C. Seam alerts you if the reported temperature is lower than this value. You can specify either `lower_limit` but not both.
+     * @param float $lower_limit_fahrenheit Lower temperature limit in in °F. Seam alerts you if the reported temperature is lower than this value. You can specify either `lower_limit` but not both.
+     * @param float $upper_limit_celsius Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either `upper_limit` but not both.
+     * @param float $upper_limit_fahrenheit Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either `upper_limit` but not both.
+     * @return void OK
+     */
     public function set_temperature_threshold(
         string $device_id,
         ?float $lower_limit_celsius = null,
@@ -5896,6 +7509,23 @@ class ThermostatsClient
         );
     }
 
+    /**
+     * Updates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $climate_preset_key Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+     * @param string $device_id ID of the thermostat device for which you want to update a climate preset.
+     * @param string $climate_preset_mode The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+     * @param float $cooling_set_point_celsius Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+     * @param float $cooling_set_point_fahrenheit Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+     * @param mixed $ecobee_metadata Metadata specific to the Ecobee climate, if applicable.
+     * @param string $fan_mode_setting Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+     * @param float $heating_set_point_celsius Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+     * @param float $heating_set_point_fahrenheit Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+     * @param string $hvac_mode_setting Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+     * @param bool $manual_override_allowed Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+     * @param string $name User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+     * @return void OK
+     */
     public function update_climate_preset(
         string $climate_preset_key,
         string $device_id,
@@ -5966,6 +7596,19 @@ class ThermostatsClient
         );
     }
 
+    /**
+     * Updates the thermostat weekly program for a thermostat device. To configure a weekly program, specify the ID of the daily program that you want to use for each day of the week. When you update a weekly program, the set of programs that you specify overwrites any previous weekly program for the thermostat.
+     *
+     * @param string $device_id ID of the thermostat device for which you want to update the weekly program.
+     * @param string $friday_program_id ID of the thermostat daily program to run on Fridays.
+     * @param string $monday_program_id ID of the thermostat daily program to run on Mondays.
+     * @param string $saturday_program_id ID of the thermostat daily program to run on Saturdays.
+     * @param string $sunday_program_id ID of the thermostat daily program to run on Sundays.
+     * @param string $thursday_program_id ID of the thermostat daily program to run on Thursdays.
+     * @param string $tuesday_program_id ID of the thermostat daily program to run on Tuesdays.
+     * @param string $wednesday_program_id ID of the thermostat daily program to run on Wednesdays.
+     * @return ActionAttempt OK
+     */
     public function update_weekly_program(
         string $device_id,
         ?string $friday_program_id = null,
@@ -6031,6 +7674,14 @@ class ThermostatsDailyProgramsClient
         $this->seam = $seam;
     }
 
+    /**
+     * Creates a new thermostat daily program. A daily program consists of a set of periods, where each period includes a start time and the key of a configured climate preset. Once you have defined a daily program, you can assign it to one or more days within a weekly program.
+     *
+     * @param string $device_id ID of the thermostat device for which you want to create a daily program.
+     * @param string $name Name of the thermostat daily program.
+     * @param array $periods Array of thermostat daily program periods.
+     * @return ThermostatDailyProgram OK
+     */
     public function create(
         string $device_id,
         string $name,
@@ -6059,6 +7710,12 @@ class ThermostatsDailyProgramsClient
         );
     }
 
+    /**
+     * Deletes a thermostat daily program.
+     *
+     * @param string $thermostat_daily_program_id ID of the thermostat daily program that you want to delete.
+     * @return void OK
+     */
     public function delete(string $thermostat_daily_program_id): void
     {
         $request_payload = [];
@@ -6076,6 +7733,14 @@ class ThermostatsDailyProgramsClient
         );
     }
 
+    /**
+     * Updates a specified thermostat daily program. The periods that you specify overwrite any existing periods for the daily program.
+     *
+     * @param string $name Name of the thermostat daily program that you want to update.
+     * @param array $periods Array of thermostat daily program periods. The periods that you specify overwrite any existing periods for the daily program.
+     * @param string $thermostat_daily_program_id ID of the thermostat daily program that you want to update.
+     * @return ActionAttempt OK
+     */
     public function update(
         string $name,
         array $periods,
@@ -6123,6 +7788,18 @@ class ThermostatsSchedulesClient
         $this->seam = $seam;
     }
 
+    /**
+     * Creates a new [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $climate_preset_key Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the new thermostat schedule.
+     * @param string $device_id ID of the thermostat device for which you want to create a schedule.
+     * @param string $ends_at Date and time at which the new thermostat schedule ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @param string $starts_at Date and time at which the new thermostat schedule starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @param bool $is_override_allowed Indicates whether a person at the thermostat or using the API can change the thermostat's settings while the new schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+     * @param int $max_override_period_minutes Number of minutes for which a person at the thermostat or using the API can change the thermostat's settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+     * @param string $name Name of the thermostat schedule.
+     * @return ThermostatSchedule OK
+     */
     public function create(
         string $climate_preset_key,
         string $device_id,
@@ -6167,6 +7844,12 @@ class ThermostatsSchedulesClient
         return ThermostatSchedule::from_json($res->thermostat_schedule);
     }
 
+    /**
+     * Deletes a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $thermostat_schedule_id ID of the thermostat schedule that you want to delete.
+     * @return void OK
+     */
     public function delete(string $thermostat_schedule_id): void
     {
         $request_payload = [];
@@ -6184,6 +7867,12 @@ class ThermostatsSchedulesClient
         );
     }
 
+    /**
+     * Returns a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+     *
+     * @param string $thermostat_schedule_id ID of the thermostat schedule that you want to get.
+     * @return ThermostatSchedule OK
+     */
     public function get(string $thermostat_schedule_id): ThermostatSchedule
     {
         $request_payload = [];
@@ -6203,6 +7892,13 @@ class ThermostatsSchedulesClient
         return ThermostatSchedule::from_json($res->thermostat_schedule);
     }
 
+    /**
+     * Returns a list of all [thermostat schedules](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+     *
+     * @param string $device_id ID of the thermostat device for which you want to list schedules.
+     * @param string $user_identifier_key User identifier key by which to filter the list of returned thermostat schedules.
+     * @return array OK
+     */
     public function list(
         string $device_id,
         ?string $user_identifier_key = null,
@@ -6228,6 +7924,18 @@ class ThermostatsSchedulesClient
         );
     }
 
+    /**
+     * Updates a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+     *
+     * @param string $thermostat_schedule_id ID of the thermostat schedule that you want to update.
+     * @param string $climate_preset_key Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the thermostat schedule.
+     * @param string $ends_at Date and time at which the thermostat schedule ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @param bool $is_override_allowed Indicates whether a person at the thermostat or using the API can change the thermostat's settings while the schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+     * @param int $max_override_period_minutes Number of minutes for which a person at the thermostat or using the API can change the thermostat's settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+     * @param string $name Name of the thermostat schedule.
+     * @param string $starts_at Date and time at which the thermostat schedule starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+     * @return void OK
+     */
     public function update(
         string $thermostat_schedule_id,
         ?string $climate_preset_key = null,
@@ -6282,6 +7990,17 @@ class ThermostatsSimulateClient
         $this->seam = $seam;
     }
 
+    /**
+     * Simulates having adjusted the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) for a [thermostat](https://docs.seam.co/capability-guides/thermostats). Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+     *
+     * @param string $device_id ID of the thermostat device for which you want to simulate having adjusted the HVAC mode.
+     * @param string $hvac_mode HVAC mode that you want to simulate.
+     * @param float $cooling_set_point_celsius Cooling [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `cooling_set_point_celsius` or `cooling_set_point_fahrenheit`.
+     * @param float $cooling_set_point_fahrenheit Cooling [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `cooling_set_point_fahrenheit` or `cooling_set_point_celsius`.
+     * @param float $heating_set_point_celsius Heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `heating_set_point_celsius` or `heating_set_point_fahrenheit`.
+     * @param float $heating_set_point_fahrenheit Heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `heating_set_point_fahrenheit` or `heating_set_point_celsius`.
+     * @return void OK
+     */
     public function hvac_mode_adjusted(
         string $device_id,
         string $hvac_mode,
@@ -6326,6 +8045,14 @@ class ThermostatsSimulateClient
         );
     }
 
+    /**
+     * Simulates a [thermostat](https://docs.seam.co/capability-guides/thermostats) reaching a specified temperature. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+     *
+     * @param string $device_id ID of the thermostat device that you want to simulate reaching a specified temperature.
+     * @param float $temperature_celsius Temperature in °C that you want simulate the thermostat reaching. You must set `temperature_celsius` or `temperature_fahrenheit`.
+     * @param float $temperature_fahrenheit Temperature in °F that you want simulate the thermostat reaching. You must set `temperature_fahrenheit` or `temperature_celsius`.
+     * @return void OK
+     */
     public function temperature_reached(
         string $device_id,
         ?float $temperature_celsius = null,
@@ -6363,6 +8090,18 @@ class UserIdentitiesClient
         $this->unmanaged = new UserIdentitiesUnmanagedClient($seam);
     }
 
+    /**
+     * Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * You must specify either `user_identity_id` or `user_identity_key` to identify the user identity.
+     *
+     * If `user_identity_key` is provided, but the user identity doesn't exist, a new user identity will be created automatically using information from the ACS user.
+     *
+     * @param string $acs_user_id ID of the access system user that you want to add to the user identity.
+     * @param string $user_identity_id ID of the user identity to which you want to add an access system user.
+     * @param string $user_identity_key Key of the user identity to which you want to add an access system user.
+     * @return void OK
+     */
     public function add_acs_user(
         string $acs_user_id,
         ?string $user_identity_id = null,
@@ -6387,6 +8126,16 @@ class UserIdentitiesClient
         );
     }
 
+    /**
+     * Creates a new [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * @param array $acs_system_ids List of access system IDs to associate with the new user identity through access system users. If there's no user with the same email address or phone number in the specified access systems, a new access system user is created. If there is an existing user with the same email or phone number in the specified access systems, the user is linked to the user identity.
+     * @param string $email_address Unique email address for the new user identity.
+     * @param string $full_name Full name of the user associated with the new user identity.
+     * @param string $phone_number Unique phone number for the new user identity in E.164 format (for example, +15555550100).
+     * @param string $user_identity_key Unique key for the new user identity.
+     * @return UserIdentity OK
+     */
     public function create(
         ?array $acs_system_ids = null,
         ?string $email_address = null,
@@ -6421,6 +8170,12 @@ class UserIdentitiesClient
         return UserIdentity::from_json($res->user_identity);
     }
 
+    /**
+     * Deletes a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This deletes the user identity and all associated resources, including any [credentials](https://docs.seam.co/api/acs/credentials), [acs users](https://docs.seam.co/api/acs/users) and [client sessions](https://docs.seam.co/api/client_sessions).
+     *
+     * @param string $user_identity_id ID of the user identity that you want to delete.
+     * @return void OK
+     */
     public function delete(string $user_identity_id): void
     {
         $request_payload = [];
@@ -6436,6 +8191,14 @@ class UserIdentitiesClient
         );
     }
 
+    /**
+     * Generates a new [instant key](https://docs.seam.co/capability-guides/instant-keys) for a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * @param string $user_identity_id ID of the user identity for which you want to generate an instant key.
+     * @param string $customization_profile_id
+     * @param float $max_use_count Maximum number of times the instant key can be used. Default: 1.
+     * @return InstantKey OK
+     */
     public function generate_instant_key(
         string $user_identity_id,
         ?string $customization_profile_id = null,
@@ -6464,6 +8227,13 @@ class UserIdentitiesClient
         return InstantKey::from_json($res->instant_key);
     }
 
+    /**
+     * Returns a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * @param string $user_identity_id ID of the user identity that you want to get.
+     * @param string $user_identity_key
+     * @return UserIdentity OK
+     */
     public function get(
         ?string $user_identity_id = null,
         ?string $user_identity_key = null,
@@ -6486,6 +8256,13 @@ class UserIdentitiesClient
         return UserIdentity::from_json($res->user_identity);
     }
 
+    /**
+     * Grants a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) access to a specified [device](https://docs.seam.co/core-concepts/devices/).
+     *
+     * @param string $device_id ID of the managed device to which you want to grant access to the user identity.
+     * @param string $user_identity_id ID of the user identity that you want to grant access to a device.
+     * @return void OK
+     */
     public function grant_access_to_device(
         string $device_id,
         string $user_identity_id,
@@ -6506,6 +8283,17 @@ class UserIdentitiesClient
         );
     }
 
+    /**
+     * Returns a list of all [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * @param string $created_before Timestamp by which to limit returned user identities. Returns user identities created before this timestamp.
+     * @param string $credential_manager_acs_system_id `acs_system_id` of the credential manager by which you want to filter the list of user identities.
+     * @param int $limit Maximum number of records to return per page.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned user identities to include all records that satisfy a partial match using `full_name`, `phone_number`, `email_address` or `user_identity_id`.
+     * @param array $user_identity_ids Array of user identity IDs by which to filter the list of user identities.
+     * @return array OK
+     */
     public function list(
         ?string $created_before = null,
         ?string $credential_manager_acs_system_id = null,
@@ -6554,6 +8342,12 @@ class UserIdentitiesClient
         );
     }
 
+    /**
+     * Returns a list of all [devices](https://docs.seam.co/core-concepts/devices) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes devices derived from the access grants assigned to the user identity and devices directly linked to the user identity.
+     *
+     * @param string $user_identity_id ID of the user identity for which you want to retrieve all accessible devices.
+     * @return array OK
+     */
     public function list_accessible_devices(string $user_identity_id): array
     {
         $request_payload = [];
@@ -6571,6 +8365,12 @@ class UserIdentitiesClient
         return array_map(fn($r) => Device::from_json($r), $res->devices);
     }
 
+    /**
+     * Returns a list of all [ACS entrances](https://docs.seam.co/api/acs/entrances) accessible to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes entrances derived from the access grants assigned to the user identity and entrances accessible through ACS users linked to the user identity.
+     *
+     * @param string $user_identity_id ID of the user identity for which you want to retrieve all accessible entrances.
+     * @return array OK
+     */
     public function list_accessible_entrances(string $user_identity_id): array
     {
         $request_payload = [];
@@ -6591,6 +8391,12 @@ class UserIdentitiesClient
         );
     }
 
+    /**
+     * Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * @param string $user_identity_id ID of the user identity for which you want to retrieve all access systems.
+     * @return array OK
+     */
     public function list_acs_systems(string $user_identity_id): array
     {
         $request_payload = [];
@@ -6608,6 +8414,12 @@ class UserIdentitiesClient
         return array_map(fn($r) => AcsSystem::from_json($r), $res->acs_systems);
     }
 
+    /**
+     * Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) assigned to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * @param string $user_identity_id ID of the user identity for which you want to retrieve all access system users.
+     * @return array OK
+     */
     public function list_acs_users(string $user_identity_id): array
     {
         $request_payload = [];
@@ -6625,6 +8437,13 @@ class UserIdentitiesClient
         return array_map(fn($r) => AcsUser::from_json($r), $res->acs_users);
     }
 
+    /**
+     * Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * @param string $acs_user_id ID of the access system user that you want to remove from the user identity..
+     * @param string $user_identity_id ID of the user identity from which you want to remove an access system user.
+     * @return void OK
+     */
     public function remove_acs_user(
         string $acs_user_id,
         string $user_identity_id,
@@ -6645,6 +8464,13 @@ class UserIdentitiesClient
         );
     }
 
+    /**
+     * Revokes access to a specified [device](https://docs.seam.co/core-concepts/devices/) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * @param string $device_id ID of the managed device to which you want to revoke access from the user identity.
+     * @param string $user_identity_id ID of the user identity from which you want to revoke access to a device.
+     * @return void OK
+     */
     public function revoke_access_to_device(
         string $device_id,
         string $user_identity_id,
@@ -6665,6 +8491,16 @@ class UserIdentitiesClient
         );
     }
 
+    /**
+     * Updates a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+     *
+     * @param string $user_identity_id ID of the user identity that you want to update.
+     * @param string $email_address Unique email address for the user identity.
+     * @param string $full_name Full name of the user associated with the user identity.
+     * @param string $phone_number Unique phone number for the user identity.
+     * @param string $user_identity_key Unique key for the user identity.
+     * @return void OK
+     */
     public function update(
         string $user_identity_id,
         ?string $email_address = null,
@@ -6707,6 +8543,12 @@ class UserIdentitiesUnmanagedClient
         $this->seam = $seam;
     }
 
+    /**
+     * Returns a specified unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+     *
+     * @param string $user_identity_id ID of the unmanaged user identity that you want to get.
+     * @return UnmanagedUserIdentity OK
+     */
     public function get(string $user_identity_id): UnmanagedUserIdentity
     {
         $request_payload = [];
@@ -6724,6 +8566,15 @@ class UserIdentitiesUnmanagedClient
         return UnmanagedUserIdentity::from_json($res->user_identity);
     }
 
+    /**
+     * Returns a list of all unmanaged [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+     *
+     * @param string $created_before Timestamp by which to limit returned unmanaged user identities. Returns user identities created before this timestamp.
+     * @param int $limit Maximum number of records to return per page.
+     * @param string $page_cursor Identifies the specific page of results to return, obtained from the previous page's `next_page_cursor`.
+     * @param string $search String for which to search. Filters returned unmanaged user identities to include all records that satisfy a partial match using `full_name`, `phone_number`, `email_address`,  `user_identity_id` or `acs_system_id`.
+     * @return array OK
+     */
     public function list(
         ?string $created_before = null,
         ?int $limit = null,
@@ -6762,6 +8613,16 @@ class UserIdentitiesUnmanagedClient
         );
     }
 
+    /**
+     * Updates an unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.
+     *
+     * This endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.
+     *
+     * @param bool $is_managed Must be set to true to convert the unmanaged user identity to managed.
+     * @param string $user_identity_id ID of the unmanaged user identity that you want to update.
+     * @param string $user_identity_key Unique key for the user identity. If not provided, the existing key will be preserved.
+     * @return void OK
+     */
     public function update(
         bool $is_managed,
         string $user_identity_id,
@@ -6796,6 +8657,13 @@ class WebhooksClient
         $this->seam = $seam;
     }
 
+    /**
+     * Creates a new [webhook](https://docs.seam.co/developer-tools/webhooks).
+     *
+     * @param string $url URL for the new webhook.
+     * @param array $event_types Types of events that you want the new webhook to receive.
+     * @return Webhook OK
+     */
     public function create(string $url, ?array $event_types = null): Webhook
     {
         $request_payload = [];
@@ -6816,6 +8684,12 @@ class WebhooksClient
         return Webhook::from_json($res->webhook);
     }
 
+    /**
+     * Deletes a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+     *
+     * @param string $webhook_id ID of the webhook that you want to delete.
+     * @return void OK
+     */
     public function delete(string $webhook_id): void
     {
         $request_payload = [];
@@ -6831,6 +8705,12 @@ class WebhooksClient
         );
     }
 
+    /**
+     * Gets a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+     *
+     * @param string $webhook_id ID of the webhook that you want to get.
+     * @return Webhook OK
+     */
     public function get(string $webhook_id): Webhook
     {
         $request_payload = [];
@@ -6848,6 +8728,11 @@ class WebhooksClient
         return Webhook::from_json($res->webhook);
     }
 
+    /**
+     * Returns a list of all [webhooks](https://docs.seam.co/developer-tools/webhooks).
+     *
+     * @return array OK
+     */
     public function list(): array
     {
         $res = $this->seam->request("POST", "/webhooks/list");
@@ -6855,6 +8740,13 @@ class WebhooksClient
         return array_map(fn($r) => Webhook::from_json($r), $res->webhooks);
     }
 
+    /**
+     * Updates a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+     *
+     * @param array $event_types Types of events that you want the webhook to receive.
+     * @param string $webhook_id ID of the webhook that you want to update.
+     * @return void OK
+     */
     public function update(array $event_types, string $webhook_id): void
     {
         $request_payload = [];
@@ -6883,6 +8775,21 @@ class WorkspacesClient
         $this->seam = $seam;
     }
 
+    /**
+     * Creates a new [workspace](https://docs.seam.co/core-concepts/workspaces).
+     *
+     * @param string $name Name of the new workspace.
+     * @param string $company_name Company name for the new workspace.
+     * @param string $connect_partner_name Connect partner name for the new workspace.
+     * @param mixed $connect_webview_customization [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) customizations for the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+     * @param bool $is_sandbox Indicates whether the new workspace is a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+     * @param string $organization_id ID of the organization to associate with the new workspace.
+     * @param string $webview_logo_shape
+     * @param string $webview_primary_button_color
+     * @param string $webview_primary_button_text_color
+     * @param string $webview_success_message
+     * @return Workspace OK
+     */
     public function create(
         string $name,
         ?string $company_name = null,
@@ -6945,6 +8852,11 @@ class WorkspacesClient
         return Workspace::from_json($res->workspace);
     }
 
+    /**
+     * Returns the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+     *
+     * @return Workspace OK
+     */
     public function get(): Workspace
     {
         $res = $this->seam->request("POST", "/workspaces/get");
@@ -6952,6 +8864,11 @@ class WorkspacesClient
         return Workspace::from_json($res->workspace);
     }
 
+    /**
+     * Returns a list of [workspaces](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+     *
+     * @return array OK
+     */
     public function list(): array
     {
         $res = $this->seam->request("POST", "/workspaces/list");
@@ -6959,6 +8876,11 @@ class WorkspacesClient
         return array_map(fn($r) => Workspace::from_json($r), $res->workspaces);
     }
 
+    /**
+     * Resets the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) associated with the authentication value. Note that this endpoint is only available for sandbox workspaces.
+     *
+     * @return ActionAttempt OK
+     */
     public function reset_sandbox(
         bool $wait_for_action_attempt = true,
     ): ActionAttempt {
@@ -6975,6 +8897,17 @@ class WorkspacesClient
         return $action_attempt;
     }
 
+    /**
+     * Updates the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+     *
+     * @param string $connect_partner_name Connect partner name for the workspace.
+     * @param mixed $connect_webview_customization [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) customizations for the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+     * @param bool $is_publishable_key_auth_enabled Indicates whether publishable key authentication is enabled for this workspace.
+     * @param bool $is_suspended Indicates whether the workspace is suspended.
+     * @param string $name Name of the workspace.
+     * @param string $organization_id ID of the organization to assign the workspace to. The authenticated user must be the owner of the workspace and an admin of the target organization.
+     * @return void OK
+     */
     public function update(
         ?string $connect_partner_name = null,
         mixed $connect_webview_customization = null,


### PR DESCRIPTION
### Motivation

- Emit rich PHPDoc for generated resource classes, properties and client methods to improve IDE hints and API discoverability.
- Propagate resource/method/property descriptions and deprecation metadata from the blueprint into the PHP SDK generation pipeline.
- Make generated client methods self-documenting so users can see parameter/return information and deprecation notices directly in the code.

### Description

- Added Handlebars helpers to produce properly-formatted PHPDoc blocks (`handlebars-helpers.ts`) and a `methodPhpDoc` helper used by `route-method.hbs` to emit method docs for client methods.
- Extended codegen models to carry description and deprecation metadata (`class-model.ts`, `resource-model.ts`, `routes.ts`) and adjusted layout context builders (`layouts/resource.ts`, `layouts/seam-client.ts`) to include those fields for templates.
- Updated templates/layouts (`codegen/layouts/partials/route-method.hbs`, `codegen/layouts/resource.hbs`) and regenerated outputs to include class-level and property-level PHPDoc comments and annotated client methods, resulting in many resource files and `SeamClient.php` being enriched with docblocks.

### Testing

- Built the TypeScript generator (`tsc` / project build) to ensure the changed codegen compiles successfully; build succeeded. 
- Ran the test suite for the codegen (project tests) after the changes; tests passed. 
- Generated the PHP SDK and ran a PHP syntax check (`php -l`) over the produced files to validate emitted code; no syntax errors found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a68d3a357388329b145138e8f69a037)